### PR TITLE
Reduce sensitive data lifetime in memory for wallet operations

### DIFF
--- a/NervaOneWalletMiner/Helpers/Hashing.cs
+++ b/NervaOneWalletMiner/Helpers/Hashing.cs
@@ -14,7 +14,7 @@ namespace NervaOneWalletMiner.Helpers
 
         private const char segmentDelimiter = ':';
 
-        public static string Hash(string input)
+        public static string Hash(char[] input)
         {
             byte[] salt = RandomNumberGenerator.GetBytes(_saltSize);
             byte[] hash = Rfc2898DeriveBytes.Pbkdf2(input, salt, _iterations, _algorithm, _keySize);
@@ -22,7 +22,7 @@ namespace NervaOneWalletMiner.Helpers
             return string.Join(segmentDelimiter, Convert.ToHexString(hash), Convert.ToHexString(salt), _iterations, _algorithm);
         }
 
-        public static bool Verify(string input, string hashString)
+        public static bool Verify(char[] input, string hashString)
         {
             string[] segments = hashString.Split(segmentDelimiter);
             byte[] hash = Convert.FromHexString(segments[0]);

--- a/NervaOneWalletMiner/Objects/DialogResult.cs
+++ b/NervaOneWalletMiner/Objects/DialogResult.cs
@@ -10,7 +10,7 @@ namespace NervaOneWalletMiner.Objects
 
         // Open, create wallet, restore from seed
         public string WalletName { get; set; } = string.Empty;
-        public string WalletPassword { get; set; } = string.Empty;
+        public char[] WalletPassword { get; set; } = [];
 
         // Create wallet, restore from seed
         public string WalletLanguage { get; set; } = Language.English;
@@ -25,13 +25,13 @@ namespace NervaOneWalletMiner.Objects
         public bool IsSplitTranfer { get;set; } = false;
 
         // Restore from Seed
-        public string SeedPhrase { get; set; } = string.Empty;
+        public char[] SeedPhrase { get; set; } = [];
         public string SeedOffset { get; set; } = string.Empty;
 
         // Restore from Keys
         public string WalletAddress { get; set;} = string.Empty;
-        public string ViewKey { get; set; } = string.Empty;
-        public string SpendKey {  get; set; } = string.Empty;
+        public char[] ViewKey { get; set; } = [];
+        public char[] SpendKey {  get; set; } = [];
 
         // Restart with commands
         public string RestartOptions { get; set; } = string.Empty;

--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/Dash/WalletServiceDASH.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/Dash/WalletServiceDASH.cs
@@ -131,7 +131,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 // Build request content json
                 var requestParams = new JObject
                 {
-                    ["passphrase"] = requestObj.Password,
+                    ["passphrase"] = new string(requestObj.Password),
                     ["timeout"] = requestObj.TimeoutInSeconds
                 };
 
@@ -170,6 +170,10 @@ namespace NervaOneWalletMiner.Rpc.Wallet
             catch (Exception ex)
             {
                 Logger.LogException("DAS.WOPW", ex);
+            }
+            finally
+            {
+                Array.Clear(requestObj.Password, 0, requestObj.Password.Length);
             }
 
             return responseObj;
@@ -243,7 +247,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 var requestParams = new JObject
                 {
                     ["wallet_name"] = requestObj.WalletName,
-                    ["passphrase"] = requestObj.Password
+                    ["passphrase"] = new string(requestObj.Password)
                 };
 
                 var requestJson = new JObject
@@ -280,6 +284,10 @@ namespace NervaOneWalletMiner.Rpc.Wallet
             catch (Exception ex)
             {
                 Logger.LogException("DAS.WCRW", ex);
+            }
+            finally
+            {
+                Array.Clear(requestObj.Password, 0, requestObj.Password.Length);
             }
 
             return responseObj;

--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceBaseXMR.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceBaseXMR.cs
@@ -83,7 +83,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 var requestParams = new JObject
                 {
                     ["filename"] = requestObj.WalletName,
-                    ["password"] = requestObj.Password
+                    ["password"] = new string(requestObj.Password)
                 };
 
                 var requestJson = new JObject
@@ -121,6 +121,10 @@ namespace NervaOneWalletMiner.Rpc.Wallet
             catch (Exception ex)
             {
                 Logger.LogException(CoinPrefix + ".WOPW", ex);
+            }
+            finally
+            {
+                Array.Clear(requestObj.Password, 0, requestObj.Password.Length);
             }
 
             return responseObj;
@@ -194,7 +198,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 var requestParams = new JObject
                 {
                     ["filename"] = requestObj.WalletName,
-                    ["password"] = requestObj.Password,
+                    ["password"] = new string(requestObj.Password),
                     ["language"] = requestObj.Language
                 };
 
@@ -233,6 +237,10 @@ namespace NervaOneWalletMiner.Rpc.Wallet
             catch (Exception ex)
             {
                 Logger.LogException(CoinPrefix + ".WCRW", ex);
+            }
+            finally
+            {
+                Array.Clear(requestObj.Password, 0, requestObj.Password.Length);
             }
 
             return responseObj;
@@ -424,9 +432,9 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 {
                     ["restore_height"] = requestObj.RestoreHeight,
                     ["filename"] = requestObj.WalletName,
-                    ["seed"] = requestObj.Seed,
+                    ["seed"] = new string(requestObj.Seed),
                     ["seed_offset"] = requestObj.SeedOffset,
-                    ["password"] = requestObj.Password,
+                    ["password"] = new string(requestObj.Password),
                     ["language"] = requestObj.Language,
                     ["autosave_current"] = requestObj.AutoSave
                 };
@@ -472,6 +480,11 @@ namespace NervaOneWalletMiner.Rpc.Wallet
             {
                 Logger.LogException(CoinPrefix + ".WRFS", ex);
             }
+            finally
+            {
+                Array.Clear(requestObj.Seed, 0, requestObj.Seed.Length);
+                Array.Clear(requestObj.Password, 0, requestObj.Password.Length);
+            }
 
             return responseObj;
         }
@@ -508,9 +521,9 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     ["restore_height"] = requestObj.RestoreHeight,
                     ["filename"] = requestObj.WalletName,
                     ["address"] = requestObj.WalletAddress,
-                    ["spendkey"] = requestObj.SpendKey,
-                    ["viewkey"] = requestObj.ViewKey,
-                    ["password"] = requestObj.Password,
+                    ["spendkey"] = new string(requestObj.SpendKey),
+                    ["viewkey"] = new string(requestObj.ViewKey),
+                    ["password"] = new string(requestObj.Password),
                     ["language"] = requestObj.Language,
                     ["autosave_current"] = requestObj.AutoSave
                 };
@@ -553,6 +566,12 @@ namespace NervaOneWalletMiner.Rpc.Wallet
             catch (Exception ex)
             {
                 Logger.LogException(CoinPrefix + ".WRFK", ex);
+            }
+            finally
+            {
+                Array.Clear(requestObj.ViewKey, 0, requestObj.ViewKey.Length);
+                Array.Clear(requestObj.SpendKey, 0, requestObj.SpendKey.Length);
+                Array.Clear(requestObj.Password, 0, requestObj.Password.Length);
             }
 
             return responseObj;
@@ -1367,13 +1386,13 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                         ResQueryKey queryKeyResponse = JsonConvert.DeserializeObject<ResQueryKey>(jsonObject.SelectToken("result").ToString());
                         if (requestObj.KeyType == KeyType.Mnemonic)
                         {
-                            responseObj.Mnemonic = queryKeyResponse.key;
+                            responseObj.Mnemonic = queryKeyResponse.key.ToCharArray();
 
                             responseObj.Error.IsError = false;
                         }
                         else if (requestObj.KeyType == KeyType.AllViewSpend)
                         {
-                            responseObj.PrivateViewKey = queryKeyResponse.key;
+                            responseObj.PrivateViewKey = queryKeyResponse.key.ToCharArray();
 
                             // Call again to get spend key
                             requestJson = new JObject
@@ -1398,7 +1417,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                                 else
                                 {
                                     queryKeyResponse = JsonConvert.DeserializeObject<ResQueryKey>(jsonObject.SelectToken("result").ToString());
-                                    responseObj.PrivateSpendKey = queryKeyResponse.key;
+                                    responseObj.PrivateSpendKey = queryKeyResponse.key.ToCharArray();
 
                                     responseObj.Error.IsError = false;
                                 }

--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceXNV.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceXNV.cs
@@ -37,9 +37,9 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 {
                     ["restore_height"] = requestObj.RestoreHeight,
                     ["filename"] = requestObj.WalletName,
-                    ["seed"] = requestObj.Seed,
+                    ["seed"] = new string(requestObj.Seed),
                     ["seed_offset"] = requestObj.SeedOffset,
-                    ["password"] = requestObj.Password,
+                    ["password"] = new string(requestObj.Password),
                     ["language"] = requestObj.Language,
                     ["autosave_current"] = requestObj.AutoSave
                 };
@@ -121,9 +121,9 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     ["restore_height"] = requestObj.RestoreHeight,
                     ["filename"] = requestObj.WalletName,
                     ["address"] = requestObj.WalletAddress,
-                    ["spendkey"] = requestObj.SpendKey,
-                    ["viewkey"] = requestObj.ViewKey,
-                    ["password"] = requestObj.Password,
+                    ["spendkey"] = new string(requestObj.SpendKey),
+                    ["viewkey"] = new string(requestObj.ViewKey),
+                    ["password"] = new string(requestObj.Password),
                     ["language"] = requestObj.Language,
                     ["autosave_current"] = requestObj.AutoSave
                 };
@@ -230,10 +230,10 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     {
                         ResQueryKey queryKeyResponse = JsonConvert.DeserializeObject<ResQueryKey>(jsonObject.SelectToken("result").ToString());
                         responseObj.PublicViewKey = queryKeyResponse.public_view_key;
-                        responseObj.PrivateViewKey = queryKeyResponse.private_view_key;
+                        responseObj.PrivateViewKey = queryKeyResponse.private_view_key.ToCharArray();
                         responseObj.PublicSpendKey = queryKeyResponse.public_spend_key;
-                        responseObj.PrivateSpendKey = queryKeyResponse.private_spend_key;
-                        responseObj.Mnemonic = queryKeyResponse.mnemonic;
+                        responseObj.PrivateSpendKey = queryKeyResponse.private_spend_key.ToCharArray();
+                        responseObj.Mnemonic = queryKeyResponse.mnemonic.ToCharArray();
 
                         responseObj.Error.IsError = false;
                     }

--- a/NervaOneWalletMiner/Rpc/Wallet/Requests/CreateWalletRequest.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Requests/CreateWalletRequest.cs
@@ -3,7 +3,7 @@
     public class CreateWalletRequest
     {
         public string WalletName { get; set; } = string.Empty;
-        public string Password { get; set; } = string.Empty;
+        public char[] Password { get; set; } = [];
         public string Language { get; set; } = string.Empty;
     }
 }

--- a/NervaOneWalletMiner/Rpc/Wallet/Requests/OpenWalletRequest.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Requests/OpenWalletRequest.cs
@@ -3,6 +3,6 @@
     public class OpenWalletRequest
     {
         public string WalletName { get; set; } = string.Empty;
-        public string Password { get; set; } = string.Empty;
+        public char[] Password { get; set; } = [];
     }
 }

--- a/NervaOneWalletMiner/Rpc/Wallet/Requests/RestoreFromKeysRequest.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Requests/RestoreFromKeysRequest.cs
@@ -4,10 +4,10 @@
     {
         public ulong RestoreHeight { get; set; } = 0;
         public string WalletAddress { get; set; } = string.Empty;
-        public string ViewKey { get; set; } = string.Empty;
-        public string SpendKey { get; set; } = string.Empty;
+        public char[] ViewKey { get; set; } = [];
+        public char[] SpendKey { get; set; } = [];
         public string WalletName { get; set; } = string.Empty;
-        public string Password { get; set; } = string.Empty;
+        public char[] Password { get; set; } = [];
         public string Language { get; set; } = string.Empty;
         public bool AutoSave { get; set; } = true;
     }

--- a/NervaOneWalletMiner/Rpc/Wallet/Requests/RestoreFromSeedRequest.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Requests/RestoreFromSeedRequest.cs
@@ -3,10 +3,10 @@
     public class RestoreFromSeedRequest
     {
         public ulong RestoreHeight { get; set; } = 0;
-        public string Seed { get; set; } = string.Empty;
+        public char[] Seed { get; set; } = [];
         public string SeedOffset { get; set; } = string.Empty;
         public string WalletName { get; set; } = string.Empty;
-        public string Password { get; set; } = string.Empty;
+        public char[] Password { get; set; } = [];
         public string Language { get; set; } = string.Empty;
         public bool AutoSave { get; set; } = true;
     }

--- a/NervaOneWalletMiner/Rpc/Wallet/Requests/UnlockWithPassRequest.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Requests/UnlockWithPassRequest.cs
@@ -2,7 +2,7 @@
 {
     public class UnlockWithPassRequest
     {
-        public string Password { get; set; } = string.Empty;
+        public char[] Password { get; set; } = [];
         public int TimeoutInSeconds { get; set; } = 60;
     }
 }

--- a/NervaOneWalletMiner/Rpc/Wallet/Responses/GetPrivateKeysResponse.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Responses/GetPrivateKeysResponse.cs
@@ -7,9 +7,9 @@ namespace NervaOneWalletMiner.Rpc.Wallet.Responses
         public ServiceError Error { get; set; } = new();
 
         public string PublicViewKey { get; set; } = string.Empty;
-        public string PrivateViewKey { get; set; } = string.Empty;
+        public char[] PrivateViewKey { get; set; } = [];
         public string PublicSpendKey { get; set; } = string.Empty;
-        public string PrivateSpendKey { get; set; } = string.Empty;
-        public string Mnemonic { get; set; } = string.Empty;
+        public char[] PrivateSpendKey { get; set; } = [];
+        public char[] Mnemonic { get; set; } = [];
     }
 }

--- a/NervaOneWalletMiner/ViewModels/WalletSetupViewModel.cs
+++ b/NervaOneWalletMiner/ViewModels/WalletSetupViewModel.cs
@@ -120,7 +120,7 @@ namespace NervaOneWalletMiner.ViewModels
             }
         }
 
-        public async Task<WalletOperationResult> CreateNewWallet(string walletName, string walletPassword, string walletLanguage)
+        public async Task<WalletOperationResult> CreateNewWallet(string walletName, char[] walletPassword, string walletLanguage)
         {
             string title = "Create Wallet";
             CreateWalletRequest request;
@@ -155,11 +155,12 @@ namespace NervaOneWalletMiner.ViewModels
             }
             finally
             {
+                Array.Clear(walletPassword, 0, walletPassword.Length);
                 request = new();
             }
         }
 
-        public async Task<WalletOperationResult> RestoreFromSeed(string seed, string seedOffset, string walletName, string walletPassword, string walletLanguage)
+        public async Task<WalletOperationResult> RestoreFromSeed(char[] seed, string seedOffset, string walletName, char[] walletPassword, string walletLanguage)
         {
             string title = "Restore from Seed";
             RestoreFromSeedRequest request;
@@ -195,26 +196,29 @@ namespace NervaOneWalletMiner.ViewModels
             }
             finally
             {
-                seed = walletPassword = string.Empty;
+                Array.Clear(seed, 0, seed.Length);
+                Array.Clear(walletPassword, 0, walletPassword.Length);
                 request = new();
             }
         }
 
-        public async Task<WalletOperationResult> RestoreFromKeys(string walletAddress, string viewKey, string spendKey, string walletName, string walletPassword, string walletLanguage)
+        public async Task<WalletOperationResult> RestoreFromKeys(string walletAddress, char[] viewKey, char[] spendKey, string walletName, char[] walletPassword, string walletLanguage)
         {
             string title = "Restore from Keys";
-            RestoreFromKeysRequest request = new()
-            {
-                WalletAddress = walletAddress,
-                ViewKey = viewKey,
-                SpendKey = spendKey,
-                WalletName = walletName,
-                Password = walletPassword,
-                Language = walletLanguage
-            };
+            RestoreFromKeysRequest request;
 
             try
             {
+                request = new()
+                {
+                    WalletAddress = walletAddress,
+                    ViewKey = viewKey,
+                    SpendKey = spendKey,
+                    WalletName = walletName,
+                    Password = walletPassword,
+                    Language = walletLanguage
+                };
+
                 RestoreFromKeysResponse response = await GlobalData.WalletService.RestoreFromKeys(GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].Rpc, request);
 
                 if (response.Error.IsError)
@@ -235,7 +239,9 @@ namespace NervaOneWalletMiner.ViewModels
             }
             finally
             {
-                viewKey = spendKey = walletPassword = string.Empty;
+                Array.Clear(viewKey, 0, viewKey.Length);
+                Array.Clear(spendKey, 0, spendKey.Length);
+                Array.Clear(walletPassword, 0, walletPassword.Length);
                 request = new();
             }
         }
@@ -301,7 +307,7 @@ namespace NervaOneWalletMiner.ViewModels
             }
         }
 
-        public bool VerifyPasswordLocally(string password)
+        public bool VerifyPasswordLocally(char[] password)
         {
             try
             {
@@ -312,6 +318,10 @@ namespace NervaOneWalletMiner.ViewModels
                 Logger.LogException("WSM.VRPL", ex);
                 return false;
             }
+            finally
+            {
+                Array.Clear(password, 0, password.Length);
+            }
         }
 
         public async Task<WalletOperationResult> UnlockWithPassword(string password)
@@ -319,7 +329,7 @@ namespace NervaOneWalletMiner.ViewModels
             string title = "Unlock Wallet";
             UnlockWithPassRequest request = new()
             {
-                Password = password,
+                Password = password.ToCharArray(),
                 TimeoutInSeconds = GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].UnlockMinutes * 60
             };
 

--- a/NervaOneWalletMiner/Views/WalletSetupView.axaml.cs
+++ b/NervaOneWalletMiner/Views/WalletSetupView.axaml.cs
@@ -87,7 +87,7 @@ namespace NervaOneWalletMiner.Views
                     return;
                 }
 
-                if (string.IsNullOrEmpty(result.WalletName) || string.IsNullOrEmpty(result.WalletPassword))
+                if (string.IsNullOrEmpty(result.WalletName) || result.WalletPassword.Length == 0)
                 {
                     return;
                 }
@@ -130,7 +130,7 @@ namespace NervaOneWalletMiner.Views
                     return;
                 }
 
-                if (string.IsNullOrEmpty(result.SeedPhrase) || string.IsNullOrEmpty(result.WalletName) || string.IsNullOrEmpty(result.WalletPassword))
+                if (result.SeedPhrase.Length == 0 || string.IsNullOrEmpty(result.WalletName) || result.WalletPassword.Length == 0)
                 {
                     return;
                 }
@@ -171,8 +171,11 @@ namespace NervaOneWalletMiner.Views
                     return;
                 }
 
-                if (string.IsNullOrEmpty(result.WalletAddress) || string.IsNullOrEmpty(result.ViewKey) || string.IsNullOrEmpty(result.SpendKey)
-                    || string.IsNullOrEmpty(result.WalletName) || string.IsNullOrEmpty(result.WalletPassword))
+                if (string.IsNullOrEmpty(result.WalletAddress)
+                    || result.ViewKey.Length == 0
+                    || result.SpendKey.Length == 0
+                    || string.IsNullOrEmpty(result.WalletName)
+                    || result.WalletPassword.Length == 0)
                 {
                     return;
                 }
@@ -240,11 +243,13 @@ namespace NervaOneWalletMiner.Views
         #region View Keys/Seed
         public async void ViewKeysSeed_Clicked(object sender, RoutedEventArgs args)
         {
+            string title = "View Keys and Seed";
+
             try
             {
                 var vm = GetVm();
 
-                var prereq = vm.CheckPrerequisites(true, "View Keys and Seed");
+                var prereq = vm.CheckPrerequisites(true, title);
                 if (!prereq.IsSuccess)
                 {
                     await new MessageBoxView(prereq.Title, prereq.Message, true).ShowDialog(GetWindow());
@@ -268,10 +273,14 @@ namespace NervaOneWalletMiner.Views
 
                     if (GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].IsPassRequiredToOpenWallet)
                     {
-                        isAuthorized = vm.VerifyPasswordLocally(passRes.TextBoxValue);
+                        isAuthorized = vm.VerifyPasswordLocally(passRes.TextBoxValue.ToCharArray());
                         if (isAuthorized)
                         {
                             GlobalData.WalletPassProvidedTime = DateTime.Now;
+                        }
+                        else
+                        {
+                            await new MessageBoxView(title, "Incorrect password", true).ShowDialog(GetWindow());
                         }
                     }
                     else

--- a/NervaOneWalletMiner/Views/WalletView.axaml.cs
+++ b/NervaOneWalletMiner/Views/WalletView.axaml.cs
@@ -91,6 +91,9 @@ namespace NervaOneWalletMiner.Views
                         if (result != null && result.IsOk)
                         {
                             OpenUserWallet(result.WalletName, result.WalletPassword);
+
+                            // WalletPassword is zeroed inside OpenUserWallet's finally block but do it here again anyways
+                            Array.Clear(result.WalletPassword, 0, result.WalletPassword.Length);
                         }
                     }
                 }
@@ -107,15 +110,20 @@ namespace NervaOneWalletMiner.Views
             }
         }
 
-        private async void OpenUserWallet(string walletName, string walletPassword)
+        private async void OpenUserWallet(string walletName, char[] walletPassword)
         {
+            OpenWalletRequest request;
+
             try
             {
-                OpenWalletRequest request = new()
+                request = new()
                 {
                     WalletName = walletName,
                     Password = walletPassword
                 };
+
+                // Need this before OpenWallet as password will be cleared there
+                string walletPasswordHash = Hashing.Hash(walletPassword);
 
                 OpenWalletResponse response = await GlobalData.WalletService.OpenWallet(GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].Rpc, request);
 
@@ -136,8 +144,8 @@ namespace NervaOneWalletMiner.Views
 
                     if (GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].IsPassRequiredToOpenWallet)
                     {
-                        GlobalData.WalletPassProvidedTime = DateTime.Now;                        
-                        GlobalData.WalletPasswordHash = Hashing.Hash(request.Password);
+                        GlobalData.WalletPassProvidedTime = DateTime.Now;
+                        GlobalData.WalletPasswordHash = walletPasswordHash;
                     }
 
                     Logger.LogDebug("WAL.OUWT", "Wallet " + walletName + " opened successfully");
@@ -146,7 +154,12 @@ namespace NervaOneWalletMiner.Views
             catch (Exception ex)
             {
                 Logger.LogException("WAL.OUWT", ex);
-            }            
+            }
+            finally
+            {
+                Array.Clear(walletPassword, 0, walletPassword.Length);
+                request = new();
+            }
         }
         #endregion // Open Wallet
 

--- a/NervaOneWalletMiner/ViewsDialogs/CreateWalletView.axaml.cs
+++ b/NervaOneWalletMiner/ViewsDialogs/CreateWalletView.axaml.cs
@@ -48,10 +48,11 @@ namespace NervaOneWalletMiner.ViewsDialogs
                     {
                         IsOk = true,
                         WalletName = tbxWalletName.Text,
-                        WalletPassword = tbxPassword.Text,
+                        WalletPassword = tbxPassword.Text.ToCharArray(),
                         WalletLanguage = cbxLanguage.SelectedValue == null ? Language.English : cbxLanguage.SelectedValue.ToString()!
                     };
 
+                    tbxPassword.Text = string.Empty;
                     Close(result);
                 }
             }

--- a/NervaOneWalletMiner/ViewsDialogs/DisplayKeysSeedView.axaml.cs
+++ b/NervaOneWalletMiner/ViewsDialogs/DisplayKeysSeedView.axaml.cs
@@ -46,9 +46,11 @@ namespace NervaOneWalletMiner.ViewsDialogs
                 else
                 {
                     tbxPublicViewKey.Text = response.PublicViewKey;
-                    tbxPrivateViewKey.Text = response.PrivateViewKey;
+                    tbxPrivateViewKey.Text = new string(response.PrivateViewKey);
                     tbxPublicSpendKey.Text = response.PublicSpendKey;
-                    tbxPrivateSpendKey.Text = response.PrivateSpendKey;
+                    tbxPrivateSpendKey.Text = new string(response.PrivateSpendKey);
+                    Array.Clear(response.PrivateViewKey, 0, response.PrivateViewKey.Length);
+                    Array.Clear(response.PrivateSpendKey, 0, response.PrivateSpendKey.Length);
                     tbkMessage.Text = message;
                     response = new GetPrivateKeysResponse();
 
@@ -60,7 +62,8 @@ namespace NervaOneWalletMiner.ViewsDialogs
                     }
                     else
                     {
-                        tbxMnemonicSeed.Text = response.Mnemonic;
+                        tbxMnemonicSeed.Text = new string(response.Mnemonic);
+                        Array.Clear(response.Mnemonic, 0, response.Mnemonic.Length);
                         response = new GetPrivateKeysResponse();
                     }                        
                 }
@@ -221,11 +224,14 @@ namespace NervaOneWalletMiner.ViewsDialogs
 
         protected override void OnClosing(WindowClosingEventArgs e)
         {
+            // Clear sensitive items as good as we can.
             tbxPublicViewKey.Text = "";
             tbxPrivateViewKey.Text = "";
             tbxPublicSpendKey.Text = "";
             tbxPrivateSpendKey.Text = "";
             tbxMnemonicSeed.Text = "";
+
+            TopLevel.GetTopLevel(this)?.Clipboard?.ClearAsync();
 
             base.OnClosing(e);
         }

--- a/NervaOneWalletMiner/ViewsDialogs/OpenWalletView.axaml.cs
+++ b/NervaOneWalletMiner/ViewsDialogs/OpenWalletView.axaml.cs
@@ -96,9 +96,10 @@ namespace NervaOneWalletMiner.ViewsDialogs
                     {
                         IsOk = true,
                         WalletName = cbxWalletName.SelectedValue.ToString()!,
-                        WalletPassword = tbxPassword.Text!
+                        WalletPassword = tbxPassword.Text!.ToCharArray()
                     };
 
+                    tbxPassword.Text = string.Empty;
                     Close(result);
                 }
             }

--- a/NervaOneWalletMiner/ViewsDialogs/RestoreFromKeysView.axaml.cs
+++ b/NervaOneWalletMiner/ViewsDialogs/RestoreFromKeysView.axaml.cs
@@ -57,13 +57,16 @@ namespace NervaOneWalletMiner.ViewsDialogs
                     {
                         IsOk = true,
                         WalletAddress = tbxWalletAddress.Text,
-                        ViewKey = tbxViewKey.Text,
-                        SpendKey = tbxSpendKey.Text!,
+                        ViewKey = tbxViewKey.Text.ToCharArray(),
+                        SpendKey = tbxSpendKey.Text!.ToCharArray(),
                         WalletName = tbxWalletName.Text,
-                        WalletPassword = tbxPassword.Text,
+                        WalletPassword = tbxPassword.Text.ToCharArray(),
                         WalletLanguage = cbxLanguage.SelectedValue == null ? Language.English : cbxLanguage.SelectedValue.ToString()!
                     };
 
+                    tbxViewKey.Text = string.Empty;
+                    tbxSpendKey.Text = string.Empty;
+                    tbxPassword.Text = string.Empty;
                     Close(result);
                 }
             }

--- a/NervaOneWalletMiner/ViewsDialogs/RestoreFromSeedView.axaml.cs
+++ b/NervaOneWalletMiner/ViewsDialogs/RestoreFromSeedView.axaml.cs
@@ -51,13 +51,15 @@ namespace NervaOneWalletMiner.ViewsDialogs
                     DialogResult result = new()
                     {
                         IsOk = true,
-                        SeedPhrase = tbxSeedPhrase.Text,
+                        SeedPhrase = tbxSeedPhrase.Text.ToCharArray(),
                         SeedOffset = tbxSeedOffset.Text!,
                         WalletName = tbxWalletName.Text,
-                        WalletPassword = tbxPassword.Text,
+                        WalletPassword = tbxPassword.Text.ToCharArray(),
                         WalletLanguage = cbxLanguage.SelectedValue == null ? Language.English : cbxLanguage.SelectedValue.ToString()!
                     };
 
+                    tbxSeedPhrase.Text = string.Empty;
+                    tbxPassword.Text = string.Empty;
                     Close(result);
                 }
             }

--- a/NervaOneWalletMiner/ViewsDialogs/TransferFundsView.axaml.cs
+++ b/NervaOneWalletMiner/ViewsDialogs/TransferFundsView.axaml.cs
@@ -127,10 +127,11 @@ namespace NervaOneWalletMiner.ViewsDialogs
                                 if (GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].IsPassRequiredToOpenWallet)
                                 {
                                     // Self managed lock
-                                    if (Hashing.Verify(passRes.TextBoxValue, GlobalData.WalletPasswordHash))
+                                    if (Hashing.Verify(passRes.TextBoxValue.ToCharArray(), GlobalData.WalletPasswordHash))
                                     {
                                         isAuthorized = true;
                                         GlobalData.WalletPassProvidedTime = DateTime.Now;
+                                        passRes.TextBoxValue = "";
                                     }                                    
                                 }
                                 else
@@ -138,7 +139,7 @@ namespace NervaOneWalletMiner.ViewsDialogs
                                     // Lock managed by wallet
                                     UnlockWithPassRequest request = new()
                                     {
-                                        Password = passRes.TextBoxValue,
+                                        Password = passRes.TextBoxValue.ToCharArray(),
                                         TimeoutInSeconds = GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].UnlockMinutes * 60
                                     };
 


### PR DESCRIPTION
Replace string fields with char[] for passwords, seed phrases, and private keys throughout the wallet flow — from dialog input through request objects to the RPC service layer. Sensitive arrays are zeroed via Array.Clear() in finally blocks after use rather than relying on garbage collection to eventually reclaim the memory.

Also clear the clipboard on DisplayKeysSeedView close, in case the user copied a private key or seed phrase while the dialog was open.