### PR TITLE
Add sweep below functionality using sweep_all RPC with below_amount.

### DIFF
--- a/NervaOneWalletMiner/Objects/DialogResult.cs
+++ b/NervaOneWalletMiner/Objects/DialogResult.cs
@@ -38,5 +38,9 @@ namespace NervaOneWalletMiner.Objects
 
         // TextBox
         public string TextBoxValue { get; set; } = string.Empty;
+
+        // Sweep Below
+        public double SweepBelowAmount { get; set; } = 0;
+        public string SweepBelowAddress { get; set; } = string.Empty;
     }
 }

--- a/NervaOneWalletMiner/Rpc/Common/HttpHelper.cs
+++ b/NervaOneWalletMiner/Rpc/Common/HttpHelper.cs
@@ -3,6 +3,7 @@ using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace NervaOneWalletMiner.Rpc.Common
@@ -11,22 +12,31 @@ namespace NervaOneWalletMiner.Rpc.Common
     {
         private static readonly HttpClient _client = new HttpClient()
         {
-            Timeout = TimeSpan.FromSeconds(50)
+            Timeout = Timeout.InfiniteTimeSpan
         };
 
+        private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(50);
+
         public static async Task<HttpResponseMessage> GetPostFromService(string serviceUrl, string postContent)
+        {
+            return await GetPostFromService(serviceUrl, postContent, _defaultTimeout);
+        }
+
+        public static async Task<HttpResponseMessage> GetPostFromService(string serviceUrl, string postContent, TimeSpan timeout)
         {
             HttpResponseMessage response = new HttpResponseMessage();
 
             try
             {
+                using CancellationTokenSource cts = new CancellationTokenSource(timeout);
+
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, serviceUrl);
                 request.Content = new StringContent(postContent);
                 request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
                 //Logger.LogDebug("HTTP.GPFS", "Calling POST: " + serviceUrl);
 
-                response = await _client.SendAsync(request);
+                response = await _client.SendAsync(request, cts.Token);
 
                 //Logger.LogDebug("HTTP.GPFS", "Call returned: " + serviceUrl);
             }
@@ -40,10 +50,17 @@ namespace NervaOneWalletMiner.Rpc.Common
 
         public static async Task<HttpResponseMessage> GetPostFromService(string serviceUrl, string postContent, string userName, string password)
         {
+            return await GetPostFromService(serviceUrl, postContent, userName, password, _defaultTimeout);
+        }
+
+        public static async Task<HttpResponseMessage> GetPostFromService(string serviceUrl, string postContent, string userName, string password, TimeSpan timeout)
+        {
             HttpResponseMessage response = new HttpResponseMessage();
 
             try
             {
+                using CancellationTokenSource cts = new CancellationTokenSource(timeout);
+
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, serviceUrl);
 
                 var authentication = userName + ":" + password;
@@ -55,7 +72,7 @@ namespace NervaOneWalletMiner.Rpc.Common
 
                 //Logger.LogDebug("HTTP.GPSA", "Calling POST: " + serviceUrl);
 
-                response = await _client.SendAsync(request);
+                response = await _client.SendAsync(request, cts.Token);
 
                 //Logger.LogDebug("HTTP.GPSA", "Call returned: " + serviceUrl);
             }

--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/Dash/WalletServiceDASH.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/Dash/WalletServiceDASH.cs
@@ -858,6 +858,11 @@ namespace NervaOneWalletMiner.Rpc.Wallet
             // Not supported
             throw new NotImplementedException();
         }
+
+        public Task<SweepBelowResponse> SweepBelow(RpcBase rpc, SweepBelowRequest requestObj)
+        {
+            throw new NotImplementedException();
+        }
         #endregion // Unsupported Methods
     }
 }

--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceBaseXMR.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceBaseXMR.cs
@@ -1614,6 +1614,66 @@ namespace NervaOneWalletMiner.Rpc.Wallet
         }
         #endregion // Get Transfers Export
 
+        #region Sweep Below
+        /* RPC request params (sweep_all):
+         *  string address;
+         *  uint32_t account_index;
+         *  uint64_t below_amount;          OPT - only outputs below this amount will be swept
+         *  bool get_tx_keys;               OPT
+         *  bool do_not_relay;              OPT
+         *  bool get_tx_hex;                OPT
+         *  bool get_tx_metadata;           OPT
+         */
+        public async Task<SweepBelowResponse> SweepBelow(RpcBase rpc, SweepBelowRequest requestObj)
+        {
+            SweepBelowResponse responseObj = new();
+
+            try
+            {
+                dynamic paramsJson = new JObject();
+                paramsJson.address = requestObj.WalletAddress;
+                paramsJson.account_index = 0;
+                paramsJson.below_amount = AtomicUnitsFromAmount(Convert.ToDecimal(requestObj.Amount));
+
+                var requestJson = new JObject
+                {
+                    ["jsonrpc"] = "2.0",
+                    ["id"] = "0",
+                    ["method"] = "sweep_all",
+                    ["params"] = paramsJson
+                };
+
+                Logger.LogDebug(CoinPrefix + ".SWBL", "Calling sweep_all with below_amount: " + requestObj.Amount);
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString(), TimeSpan.FromMinutes(60));
+                Logger.LogDebug(CoinPrefix + ".SWBL", "sweep_all returned.");
+                if (httpResponse.IsSuccessStatusCode)
+                {
+                    dynamic jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+
+                    var error = JObject.Parse(jsonObject.ToString())["error"];
+                    if (error != null)
+                    {
+                        responseObj.Error = GetServiceError(System.Reflection.MethodBase.GetCurrentMethod()!.Name, error);
+                    }
+                    else
+                    {
+                        responseObj.Error.IsError = false;
+                    }
+                }
+                else
+                {
+                    responseObj.Error = HttpHelper.GetHttpError(System.Reflection.MethodBase.GetCurrentMethod()!.Name, httpResponse);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException(CoinPrefix + ".SWBL", ex);
+            }
+
+            return responseObj;
+        }
+        #endregion // Sweep Below
+
         #region Common Internal Helper Objects
         private class TransferEntry
         {

--- a/NervaOneWalletMiner/Rpc/Wallet/IWalletService.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/IWalletService.cs
@@ -48,5 +48,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
 
 
         Task<GetTransfersExportResponse> GetTransfersExport(RpcBase rpc, GetTransfersExportRequest requestObj);
+
+        Task<SweepBelowResponse> SweepBelow(RpcBase rpc, SweepBelowRequest requestObj);
     }
 }

--- a/NervaOneWalletMiner/Rpc/Wallet/Requests/SweepBelowRequest.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Requests/SweepBelowRequest.cs
@@ -1,0 +1,8 @@
+namespace NervaOneWalletMiner.Rpc.Wallet.Requests
+{
+    public class SweepBelowRequest
+    {
+        public double Amount { get; set; } = 0.5;
+        public string WalletAddress { get; set; } = string.Empty;
+    }
+}

--- a/NervaOneWalletMiner/Rpc/Wallet/Responses/SweepBelowResponse.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Responses/SweepBelowResponse.cs
@@ -1,0 +1,9 @@
+using NervaOneWalletMiner.Rpc.Common;
+
+namespace NervaOneWalletMiner.Rpc.Wallet.Responses
+{
+    public class SweepBelowResponse
+    {
+        public ServiceError Error { get; set; } = new();
+    }
+}

--- a/NervaOneWalletMiner/ViewModels/WalletSetupViewModel.cs
+++ b/NervaOneWalletMiner/ViewModels/WalletSetupViewModel.cs
@@ -246,6 +246,37 @@ namespace NervaOneWalletMiner.ViewModels
             }
         }
 
+        public async Task<WalletOperationResult> SweepBelow(double amount, string address)
+        {
+            string title = "Sweep Below";
+
+            try
+            {
+                SweepBelowRequest request = new()
+                {
+                    Amount = amount,
+                    WalletAddress = address
+                };
+
+                Logger.LogDebug("WSM.SWBL", "Calling SweepBelow");
+                SweepBelowResponse response = await GlobalData.WalletService.SweepBelow(GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].Rpc, request);
+
+                if (response.Error.IsError)
+                {
+                    Logger.LogError("WSM.SWBL", "Failed to sweep below | Code: " + response.Error.Code + " | Message: " + response.Error.Message + " | Content: " + response.Error.Content);
+                    return new WalletOperationResult(false, title, "Error running sweep below\r\n" + response.Error.Message);
+                }
+
+                Logger.LogDebug("WSM.SWBL", "Sweep below returned successfully");
+                return new WalletOperationResult(true, title, "Sweep below submitted successfully");
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("WSM.SWBL", ex);
+                return new WalletOperationResult(false, title, ex.Message);
+            }
+        }
+
         public async Task<WalletOperationResult> RescanSpent()
         {
             string title = "Rescan Spent";

--- a/NervaOneWalletMiner/Views/WalletSetupView.axaml
+++ b/NervaOneWalletMiner/Views/WalletSetupView.axaml
@@ -71,6 +71,12 @@
 					DockPanel.Dock="Right"
 					Margin="0,10,0,0"
 					Click="RescanBlockchain_Clicked"/>
+
+			<Button Name="btnSweepBelow"
+					Content="Run Sweep Below On Wallet"
+					DockPanel.Dock="Right"
+					Margin="0,10,0,0"
+					Click="SweepBelow_Clicked"/>
 		
 			<Separator Margin="0,20,0,0"/>
 

--- a/NervaOneWalletMiner/Views/WalletSetupView.axaml.cs
+++ b/NervaOneWalletMiner/Views/WalletSetupView.axaml.cs
@@ -39,6 +39,39 @@ namespace NervaOneWalletMiner.Views
             }
         }
 
+        public async void SweepBelow_Clicked(object sender, RoutedEventArgs args)
+        {
+            try
+            {
+                var prereq = GetVm().CheckPrerequisites(true, "Sweep Below");
+                if (!prereq.IsSuccess)
+                {
+                    await new MessageBoxView(prereq.Title, prereq.Message, true).ShowDialog(GetWindow());
+                    return;
+                }
+
+                var window = new SweepBelowView();
+                DialogResult result = await window.ShowDialog<DialogResult>(GetWindow());
+
+                if (result == null || !result.IsOk)
+                {
+                    return;
+                }
+
+                var opResult = await GetVm().SweepBelow(result.SweepBelowAmount, result.SweepBelowAddress);
+
+                var owner = TopLevel.GetTopLevel(this) as Window;
+                if (owner != null)
+                {
+                    await new MessageBoxView(opResult.Title, opResult.Message, true).ShowDialog(owner);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("WAS.SWBC", ex);
+            }
+        }
+
         public void OpenWalletExportsFolder_Clicked(object sender, RoutedEventArgs args)
         {
             try

--- a/NervaOneWalletMiner/ViewsDialogs/SweepBelowView.axaml
+++ b/NervaOneWalletMiner/ViewsDialogs/SweepBelowView.axaml
@@ -1,0 +1,47 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="350"
+		x:Class="NervaOneWalletMiner.ViewsDialogs.SweepBelowView"
+		Width="500"
+		Height="350"
+		Topmost="True"
+		WindowStartupLocation="CenterOwner"
+        Title="Sweep Below">
+
+	<StackPanel Spacing="5" Margin="10">
+		<Label Name="lblTitle"
+			   Content="Send all unlocked outputs below the threashhold to an address."/>
+		<TextBlock Name="tbkSeepBelowMsg" TextWrapping="Wrap">
+			   If you have a lot of small inputs such as mining rewards, your transfer might fail. Use sweep below to combined those inputs. You can set the same address to send swept funds to or provide another one.
+		</TextBlock>
+
+		<TextBlock Name="tbkSeepBelowWarning" TextWrapping="Wrap" FontWeight="Bold">
+			   IMPORTANT: This process can take very long time if your wallet has a lot of transactions below your sweep amount.
+		</TextBlock>
+
+		<Label Name="lblAmount"
+			   Margin="0,10,0,0"
+			   Content="Amount to sweep below:"/>
+		<TextBox Name="tbxAmount" Text="0.5"/>
+
+		<Label Name="lblAddress"
+			   Margin="0,10,0,0"
+			   Content="Address to send swept funds to:"/>
+		<TextBox Name="tbxAddress" Watermark="Wallet address"/>
+
+		<DockPanel Margin="0,15,0,0">
+			<Button Name="btnRun"
+					Content="Run Sweep Below"
+					Click="RunButton_Clicked"
+					IsDefault="True"/>
+
+			<Button Name="btnCancel"
+					Content="Cancel"
+					Click="CancelButton_Clicked"
+					Margin="10,0,0,0"/>
+		</DockPanel>
+	</StackPanel>
+
+</Window>

--- a/NervaOneWalletMiner/ViewsDialogs/SweepBelowView.axaml.cs
+++ b/NervaOneWalletMiner/ViewsDialogs/SweepBelowView.axaml.cs
@@ -1,0 +1,80 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using NervaOneWalletMiner.Helpers;
+using NervaOneWalletMiner.Objects;
+using System;
+
+namespace NervaOneWalletMiner.ViewsDialogs;
+
+public partial class SweepBelowView : Window
+{
+    Window GetWindow() => TopLevel.GetTopLevel(this) as Window ?? throw new NullReferenceException("Invalid Owner");
+
+    public SweepBelowView()
+    {
+        try
+        {
+            InitializeComponent();
+            Icon = GlobalMethods.GetWindowIcon();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogException("SBD.CONS", ex);
+        }
+    }
+
+    public async void RunButton_Clicked(object sender, RoutedEventArgs args)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(tbxAmount.Text) || string.IsNullOrEmpty(tbxAddress.Text))
+            {
+                await Dispatcher.UIThread.Invoke(async () =>
+                {
+                    await new MessageBoxView("Sweep Below", "Amount and address are required", true).ShowDialog(GetWindow());
+                });
+                return;
+            }
+
+            if (!double.TryParse(tbxAmount.Text, out double amount) || amount <= 0)
+            {
+                await Dispatcher.UIThread.Invoke(async () =>
+                {
+                    await new MessageBoxView("Sweep Below", "Amount must be a positive number", true).ShowDialog(GetWindow());
+                });
+                return;
+            }
+
+            DialogResult result = new()
+            {
+                IsOk = true,
+                SweepBelowAmount = amount,
+                SweepBelowAddress = tbxAddress.Text
+            };
+
+            Close(result);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogException("SBD.RNBC", ex);
+        }
+    }
+
+    public void CancelButton_Clicked(object sender, RoutedEventArgs args)
+    {
+        try
+        {
+            DialogResult result = new()
+            {
+                IsCancel = true
+            };
+
+            Close(result);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogException("SBD.CLBC", ex);
+        }
+    }
+}


### PR DESCRIPTION
Adds SweepBelowView dialog (amount threshold + destination address),
wires it into Wallet Setup, and implements the sweep_all RPC call in
WalletServiceBaseXMR with a 60-minute timeout to handle wallets with
many small inputs. HttpHelper refactored to support per-request
timeouts via CancellationTokenSource.

Closes #22