### PR TITLE
Reduce CPU usage and improve UI rendering

### DIFF
--- a/NervaOneWalletMiner.Android/MainActivity.cs
+++ b/NervaOneWalletMiner.Android/MainActivity.cs
@@ -1,4 +1,4 @@
-﻿using Android.App;
+using Android.App;
 using Android.Content;
 using Android.Content.PM;
 using Android.OS;
@@ -29,7 +29,14 @@ public class MainActivity : AvaloniaMainActivity<App>
     {
         return base.CustomizeAppBuilder(builder)
             .WithInterFont()
-            .UseReactiveUI();
+            .UseReactiveUI()
+            // EGL (GPU) mode renders at the display refresh rate via Choreographer even when
+            // the UI is idle, causing constant background CPU/battery drain. Software mode
+            // renders only on dirty regions, matching the idle behavior of Avalonia 11.0.x.
+            .With(new AndroidPlatformOptions
+            {
+                RenderingMode = [AndroidRenderingMode.Software]
+            });
     }
 
     protected override void OnDestroy()

--- a/NervaOneWalletMiner.Android/MainActivity.cs
+++ b/NervaOneWalletMiner.Android/MainActivity.cs
@@ -8,6 +8,7 @@ using Avalonia.Android;
 using NervaOneWalletMiner.Android.Services;
 using NervaOneWalletMiner.Helpers;
 using ReactiveUI.Avalonia;
+using System;
 
 namespace NervaOneWalletMiner.Android;
 
@@ -37,6 +38,37 @@ public class MainActivity : AvaloniaMainActivity<App>
             {
                 RenderingMode = [AndroidRenderingMode.Software]
             });
+    }
+
+    protected override void OnPause()
+    {
+        base.OnPause();
+
+        try
+        {
+            // Activity is no longer visible (screen off, app switched, etc.).
+            // Skip all UI updates and RPC calls until the user returns — only
+            // daemon keep-alive checks continue to run in the background.
+            MasterProcess.EnterBackgroundMode();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogException("MNA.ONPS", ex);
+        }
+    }
+
+    protected override void OnResume()
+    {
+        base.OnResume();
+
+        try
+        {
+            MasterProcess.ExitBackgroundMode();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogException("MNA.ONRS", ex);
+        }
     }
 
     protected override void OnDestroy()

--- a/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
+++ b/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
@@ -5,8 +5,8 @@
     <SupportedOSPlatformVersion>34</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ApplicationId>one.nerva.mobile</ApplicationId>
-    <ApplicationVersion>13</ApplicationVersion>
-    <ApplicationDisplayVersion>1.0.13</ApplicationDisplayVersion>
+    <ApplicationVersion>14</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0.14</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidEnableProfiledAot>False</AndroidEnableProfiledAot>
     <RuntimeIdentifier>android-arm64</RuntimeIdentifier>

--- a/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
+++ b/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
@@ -5,8 +5,8 @@
     <SupportedOSPlatformVersion>34</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ApplicationId>one.nerva.mobile</ApplicationId>
-    <ApplicationVersion>10</ApplicationVersion>
-    <ApplicationDisplayVersion>1.0.10</ApplicationDisplayVersion>
+    <ApplicationVersion>12</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0.12</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidEnableProfiledAot>False</AndroidEnableProfiledAot>
     <RuntimeIdentifier>android-arm64</RuntimeIdentifier>

--- a/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
+++ b/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
@@ -5,8 +5,8 @@
     <SupportedOSPlatformVersion>34</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ApplicationId>one.nerva.mobile</ApplicationId>
-    <ApplicationVersion>12</ApplicationVersion>
-    <ApplicationDisplayVersion>1.0.12</ApplicationDisplayVersion>
+    <ApplicationVersion>13</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0.13</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidEnableProfiledAot>False</AndroidEnableProfiledAot>
     <RuntimeIdentifier>android-arm64</RuntimeIdentifier>

--- a/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
+++ b/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
@@ -5,8 +5,8 @@
     <SupportedOSPlatformVersion>34</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ApplicationId>one.nerva.mobile</ApplicationId>
-    <ApplicationVersion>14</ApplicationVersion>
-    <ApplicationDisplayVersion>1.0.14</ApplicationDisplayVersion>
+    <ApplicationVersion>15</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0.15</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidEnableProfiledAot>False</AndroidEnableProfiledAot>
     <RuntimeIdentifier>android-arm64</RuntimeIdentifier>

--- a/NervaOneWalletMiner.Desktop/Program.cs
+++ b/NervaOneWalletMiner.Desktop/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 
 using Avalonia;
 using ReactiveUI.Avalonia;
@@ -17,9 +18,27 @@ class Program
 
     // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp()
-        => AppBuilder.Configure<App>()
+    {
+        AppBuilder builder = AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace()
             .UseReactiveUI();
+
+        // Avalonia 11.1+ defaults to WinUIComposition → DirectComposition, both of which
+        // run a continuous compositor loop even when the UI is idle. On low-end or older
+        // hardware this causes significant baseline CPU usage.
+        // Force RedirectionSurface, the traditional GDI-backed mode that only renders on
+        // dirty regions — matching the idle behavior of Avalonia 11.0.x.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            builder = builder.With(new Win32PlatformOptions
+            {
+                RenderingMode = [Win32RenderingMode.AngleEgl, Win32RenderingMode.Software],
+                CompositionMode = [Win32CompositionMode.RedirectionSurface]
+            });
+        }
+
+        return builder;
+    }
 }

--- a/NervaOneWalletMiner/Helpers/GlobalData.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalData.cs
@@ -16,7 +16,7 @@ namespace NervaOneWalletMiner.Helpers
     {
         public const string AppNameMain = "NervaOne";
         public const string AppNameDesktop = "NervaOneDesktop";
-        public const string Version = "0.8.5.4";
+        public const string Version = "0.8.5.5";
 
         public const string CliToolsDirName = "cli";
         public const string WalletDirName = "wallets";

--- a/NervaOneWalletMiner/Helpers/GlobalMethods.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalMethods.cs
@@ -1263,6 +1263,8 @@ namespace NervaOneWalletMiner.Helpers
             {
                 GlobalData.ViewModelPages[SplitViewPages.WalletSetup] = new WalletSetupViewModel();
             }
+
+            UIManager.UpdateCoinIcon(GetLogo());
         }
         #endregion // Misc Methods
 

--- a/NervaOneWalletMiner/Helpers/Logger.cs
+++ b/NervaOneWalletMiner/Helpers/Logger.cs
@@ -22,7 +22,7 @@ namespace NervaOneWalletMiner.Helpers
             fileAppender.RollingStyle = RollingFileAppender.RollingMode.Date;
             fileAppender.DatePattern = "_yyyMMdd.'log'";
             fileAppender.StaticLogFileName = false;
-            fileAppender.LockingModel = new FileAppender.MinimalLock();
+            fileAppender.LockingModel = new FileAppender.ExclusiveLock();
             
             PatternLayout pl = new PatternLayout();
             pl.ConversionPattern = "%-5level %date - %message%newline";

--- a/NervaOneWalletMiner/Helpers/MasterProcess.cs
+++ b/NervaOneWalletMiner/Helpers/MasterProcess.cs
@@ -1,21 +1,35 @@
 ﻿using NervaOneWalletMiner.Objects.Constants;
-using NervaOneWalletMiner.Rpc.Daemon.Requests;
-using NervaOneWalletMiner.Rpc.Wallet.Requests;
-using NervaOneWalletMiner.Rpc.Wallet.Responses;
 using NervaOneWalletMiner.ViewModels;
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace NervaOneWalletMiner.Helpers
 {
     public static class MasterProcess
     {
         public static System.Timers.Timer? _masterUpdateTimer;
-        public const int _masterTimerInterval = 1000;        
+        public static readonly int _masterTimerInterval = GlobalMethods.IsAndroid() ? 2000 : 1000;
         public static DateTime _cliToolsRunningLastCheck = DateTime.MinValue;
         public static bool _killMasterProcess = false;
         public static int _masterTimerCount = 0;
+
+        // When the Android activity is paused (screen off / app in background), skip all UI
+        // updates and RPC calls — only keep-alive checks still run.
+        public static volatile bool _isInBackgroundMode = false;
+
+        // Set by GetAndSetDaemonData when fresh data arrives; cleared after UpdateDaemonView runs.
+        // Prevents UpdateDaemonView from firing every timer tick when data only changes every
+        // TimerIntervalMultiplier ticks.
+        public static volatile bool _isDaemonDataFresh = false;
+
+        public static void EnterBackgroundMode()
+        {
+            _isInBackgroundMode = true;
+        }
+
+        public static void ExitBackgroundMode()
+        {
+            _isInBackgroundMode = false;
+        }
         
 
         public static void StartMasterUpdateProcess()
@@ -56,13 +70,8 @@ namespace NervaOneWalletMiner.Helpers
                     _masterUpdateTimer.Stop();
                 }
 
-                if (UIManager.GetCoinIcon() != GlobalMethods.GetLogo())
-                {
-                    UIManager.UpdateCoinIcon(GlobalMethods.GetLogo());
-                }
-
-                // If kill master process is issued at any point, skip everything else and do not restart master timer            
-                if (_cliToolsRunningLastCheck.AddSeconds(10) < DateTime.Now)
+                // If kill master process is issued at any point, skip everything else and do not restart master timer
+                if (_cliToolsRunningLastCheck.AddSeconds(30) < DateTime.Now)
                 {
                     _cliToolsRunningLastCheck = DateTime.Now;
 
@@ -135,78 +144,83 @@ namespace NervaOneWalletMiner.Helpers
                 }
 
 
-                // Get Daemon data
-                if(!GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].IsWalletOnly)
+                if (!_isInBackgroundMode)
                 {
-                    if (!_killMasterProcess && _masterTimerCount % GlobalData.AppSettings.TimerIntervalMultiplier == 0)
+                    // Get Daemon data
+                    if (!GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].IsWalletOnly)
+                    {
+                        if (!_killMasterProcess && _masterTimerCount % GlobalData.AppSettings.TimerIntervalMultiplier == 0)
+                        {
+                            UIManager.HandleNetworkStats();
+                            UIManager.GetAndSetDaemonData();
+                        }
+
+                        // Actual Daemon UI update — only run when GetAndSetDaemonData just produced
+                        // fresh data, not on every timer tick. _isDaemonDataFresh is set by
+                        // GetAndSetDaemonData and cleared here after the view is updated.
+                        if (_isDaemonDataFresh && GlobalData.IsGetAndSetDaemonDataComplete)
+                        {
+                            _isDaemonDataFresh = false;
+                            UIManager.UpdateDaemonView();
+                            UIManager.UpdateStatusBar();
+                        }
+                    }
+                    else
                     {
                         UIManager.HandleNetworkStats();
-                        UIManager.GetAndSetDaemonData();
-                    }
-
-                    // Actual Daemon UI update
-                    if (GlobalData.IsGetAndSetDaemonDataComplete)
-                    {
-                        UIManager.UpdateDaemonView();
                         UIManager.UpdateStatusBar();
                     }
-                }
-                else
-                {
-                    UIManager.HandleNetworkStats();
-                    UIManager.UpdateStatusBar();
-                }
 
-                // Get Wallets/Transfers data
-                if (!_killMasterProcess
-                    && (GlobalData.IsInitialDaemonConnectionSuccess || GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].IsWalletOnly)
-                    && GlobalData.IsWalletOpen)
-                {
-                    if (GlobalData.IsWalletJustOpened || (_masterTimerCount % (GlobalData.AppSettings.TimerIntervalMultiplier * 2) == 0))
+                    // Get Wallets/Transfers data
+                    if (!_killMasterProcess
+                        && (GlobalData.IsInitialDaemonConnectionSuccess || GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].IsWalletOnly)
+                        && GlobalData.IsWalletOpen)
                     {
-                        UIManager.CallWalletDataMethodsInSync();
-                    }
-                }
-
-                // Actual Wallets/Transfers UI update
-                if(GlobalData.IsGetAndSetWalletDataComplete)
-                {
-                    UIManager.UpdateWalletView();
-                }
-                if (GlobalData.IsGetAndSetTransfersDataComplete)
-                {
-                    UIManager.UpdateTransfersView();
-                }
-
-
-                if (GlobalData.IsWalletJustOpened)
-                {
-                    // Will use this to auto-save wallet so need to reset it at the end
-                    GlobalData.IsWalletJustOpened = false;
-                }
-
-                if (GlobalData.IsWalletOpen & _masterTimerCount % 300 == 0)
-                {
-                    if (GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].IsSavingWalletSupported)
-                    {
-                        // Auto save wallet every 5 min
-                        Logger.LogDebug("MSP.MUPS", "Auto saving wallet: " + GlobalData.OpenedWalletName);
-
-                        GlobalMethods.SaveWallet();
-                    }
-                }
-
-                if (!GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].IsWalletOnly)
-                {
-                    if (GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].EnableConnectionsGuard)
-                    {
-                        if (GlobalData.ConnectGuardLastGoodTime.AddMinutes(GlobalData.ConnectGuardMinutes * GlobalData.ConnectGuardRestartCount) < DateTime.Now)
+                        if (GlobalData.IsWalletJustOpened || (_masterTimerCount % (GlobalData.AppSettings.TimerIntervalMultiplier * 2) == 0))
                         {
-                            Logger.LogDebug("MSP.MUPS", "Connections guard forcing restart. Last good time: " + GlobalData.ConnectGuardLastGoodTime.ToLongTimeString() + " | Restart Ct: " + GlobalData.ConnectGuardRestartCount);
+                            UIManager.CallWalletDataMethodsInSync();
+                        }
+                    }
 
-                            // Pop blocks every 3rd restart
-                            ConnectionsGuardRestart(GlobalData.ConnectGuardRestartCount % 3 == 0);
-                            GlobalData.ConnectGuardRestartCount++;
+                    // Actual Wallets/Transfers UI update
+                    if (GlobalData.IsGetAndSetWalletDataComplete)
+                    {
+                        UIManager.UpdateWalletView();
+                    }
+                    if (GlobalData.IsGetAndSetTransfersDataComplete)
+                    {
+                        UIManager.UpdateTransfersView();
+                    }
+
+                    if (GlobalData.IsWalletJustOpened)
+                    {
+                        // Will use this to auto-save wallet so need to reset it at the end
+                        GlobalData.IsWalletJustOpened = false;
+                    }
+
+                    if (GlobalData.IsWalletOpen & _masterTimerCount % 300 == 0)
+                    {
+                        if (GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].IsSavingWalletSupported)
+                        {
+                            // Auto save wallet every 5 min
+                            Logger.LogDebug("MSP.MUPS", "Auto saving wallet: " + GlobalData.OpenedWalletName);
+
+                            GlobalMethods.SaveWallet();
+                        }
+                    }
+
+                    if (!GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].IsWalletOnly)
+                    {
+                        if (GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].EnableConnectionsGuard)
+                        {
+                            if (GlobalData.ConnectGuardLastGoodTime.AddMinutes(GlobalData.ConnectGuardMinutes * GlobalData.ConnectGuardRestartCount) < DateTime.Now)
+                            {
+                                Logger.LogDebug("MSP.MUPS", "Connections guard forcing restart. Last good time: " + GlobalData.ConnectGuardLastGoodTime.ToLongTimeString() + " | Restart Ct: " + GlobalData.ConnectGuardRestartCount);
+
+                                // Pop blocks every 3rd restart
+                                ConnectionsGuardRestart(GlobalData.ConnectGuardRestartCount % 3 == 0);
+                                GlobalData.ConnectGuardRestartCount++;
+                            }
                         }
                     }
                 }

--- a/NervaOneWalletMiner/Helpers/MasterProcess.cs
+++ b/NervaOneWalletMiner/Helpers/MasterProcess.cs
@@ -29,6 +29,7 @@ namespace NervaOneWalletMiner.Helpers
         public static void ExitBackgroundMode()
         {
             _isInBackgroundMode = false;
+            _masterTimerCount = 0;
         }
         
 

--- a/NervaOneWalletMiner/Helpers/UIManager.cs
+++ b/NervaOneWalletMiner/Helpers/UIManager.cs
@@ -418,153 +418,152 @@ namespace NervaOneWalletMiner.Helpers
         {
             try
             {
+                WalletViewModel walletVm = (WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet];
+                MainViewModel mainViewVm = (MainViewModel)GlobalData.ViewModelPages[SplitViewPages.MainView];
+
                 if (GlobalData.IsWalletOpen)
                 {
-                    if (!((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).TotalCoins.Equals(GlobalData.WalletStats.BalanceTotal.ToString()))
-                    {
-                        ((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).TotalCoins = GlobalData.WalletStats.BalanceTotal.ToString();
-                    }
+                    // Compute collection changes on timer thread before marshaling to UI thread
+                    List<Account> deleteAccounts = [];
+                    List<Account> addAccounts = [];
 
-                    if (!((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).UnlockedCoins.Equals(GlobalData.WalletStats.BalanceUnlocked.ToString()))
+                    if (walletVm.WalletAddresses.Count > 0)
                     {
-                        ((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).UnlockedCoins = GlobalData.WalletStats.BalanceUnlocked.ToString();
-                    }
-
-                    string totalLockedLabel = "Total " + GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].DisplayUnits + ":";
-                    if (!((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).TotalLockedLabel.Equals(totalLockedLabel))
-                    {
-                        ((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).TotalLockedLabel = totalLockedLabel;
-                    }
-
-                    string totalUnlockedLabel = "Unlocked " + GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].DisplayUnits + ":";
-                    if (!((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).TotalUnlockedLabel.Equals(totalUnlockedLabel))
-                    {
-                        ((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).TotalUnlockedLabel = totalUnlockedLabel;
-                    }
-
-                    if (((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).WalletAddresses.Count == 0 && GlobalData.WalletStats.Subaddresses.Values.Count > 0)
-                    {
-                        ObservableCollection<Account> initialAccounts = [.. GlobalData.WalletStats.Subaddresses.Values];
-
-                        if (initialAccounts.Count > 0)
-                        {
-                            Dispatcher.UIThread.Invoke(() =>
-                            {
-                                ((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).WalletAddresses = [.. initialAccounts];
-                            });
-                        }
-                    }
-                    else
-                    {
-                        // Trying to avoid loop within a loop
-                        List<Account> deleteWallets = [];
                         HashSet<uint> checkedIndexes = [];
 
-                        foreach (Account wallet in ((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).WalletAddresses)
+                        foreach (Account wallet in walletVm.WalletAddresses)
                         {
                             checkedIndexes.Add(wallet.Index);
 
-                            if (GlobalData.WalletStats.Subaddresses.ContainsKey(wallet.Index))
+                            if (!GlobalData.WalletStats.Subaddresses.ContainsKey(wallet.Index))
                             {
-                                // Update, only if value changed
-                                // GlobalData.WalletStats.Subaddresses get cleared in asynchronouse call so sometimes even though you check if key exists, it will not exist anymore
-                                if (!wallet.Label.Equals(GlobalData.WalletStats.Subaddresses[wallet.Index].Label))
-                                {
-                                    wallet.Label = GlobalData.WalletStats.Subaddresses[wallet.Index].Label;
-                                }
-                                if (!wallet.AddressShort.Equals(GlobalData.WalletStats.Subaddresses[wallet.Index].AddressShort))
-                                {
-                                    wallet.AddressShort = GlobalData.WalletStats.Subaddresses[wallet.Index].AddressShort;
-                                }
-                                if (wallet.BalanceTotal != (GlobalData.WalletStats.Subaddresses[wallet.Index].BalanceTotal))
-                                {
-                                    wallet.BalanceTotal = GlobalData.WalletStats.Subaddresses[wallet.Index].BalanceTotal;
-                                }
-                                if (wallet.BalanceUnlocked != (GlobalData.WalletStats.Subaddresses[wallet.Index].BalanceUnlocked))
-                                {
-                                    wallet.BalanceUnlocked = GlobalData.WalletStats.Subaddresses[wallet.Index].BalanceUnlocked;
-                                }
+                                deleteAccounts.Add(wallet);
                             }
-                            else
-                            {
-                                // Wallets to remove
-                                deleteWallets.Add(wallet);
-                            }
-                        }
-
-                        foreach (Account wallet in deleteWallets)
-                        {
-                            Dispatcher.UIThread.Invoke(() =>
-                            {
-                                ((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).WalletAddresses.Remove(wallet);
-                            });
                         }
 
                         foreach (uint index in GlobalData.WalletStats.Subaddresses.Keys)
                         {
                             if (!checkedIndexes.Contains(index))
                             {
-                                // Need to add new wallet
-                                Dispatcher.UIThread.Invoke(() =>
-                                {
-                                    ((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).WalletAddresses.Add(GlobalData.WalletStats.Subaddresses[index]);
-                                });
+                                addAccounts.Add(GlobalData.WalletStats.Subaddresses[index]);
                             }
                         }
                     }
 
-                    ((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).OpenCloseWallet = StatusWallet.CloseWallet;
-
-                    // Status Bar
+                    string totalLockedLabel = "Total " + GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].DisplayUnits + ":";
+                    string totalUnlockedLabel = "Unlocked " + GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].DisplayUnits + ":";
                     string statusBarMessage = GlobalData.OpenedWalletName + " | " + GlobalData.WalletStats.BalanceTotal.ToString("F2") + " " + GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].DisplayUnits + (GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].IsWalletHeightSupported ? " | H: " + GlobalData.WalletHeight : string.Empty);
-                    if (((MainViewModel)GlobalData.ViewModelPages[SplitViewPages.MainView]).WalletStatus != statusBarMessage)
+
+                    Dispatcher.UIThread.Invoke(() =>
                     {
-                        ((MainViewModel)GlobalData.ViewModelPages[SplitViewPages.MainView]).WalletStatus = statusBarMessage;
-                    }
+                        if (!walletVm.TotalCoins.Equals(GlobalData.WalletStats.BalanceTotal.ToString()))
+                        {
+                            walletVm.TotalCoins = GlobalData.WalletStats.BalanceTotal.ToString();
+                        }
+                        if (!walletVm.UnlockedCoins.Equals(GlobalData.WalletStats.BalanceUnlocked.ToString()))
+                        {
+                            walletVm.UnlockedCoins = GlobalData.WalletStats.BalanceUnlocked.ToString();
+                        }
+                        if (!walletVm.TotalLockedLabel.Equals(totalLockedLabel))
+                        {
+                            walletVm.TotalLockedLabel = totalLockedLabel;
+                        }
+                        if (!walletVm.TotalUnlockedLabel.Equals(totalUnlockedLabel))
+                        {
+                            walletVm.TotalUnlockedLabel = totalUnlockedLabel;
+                        }
+
+                        if (walletVm.WalletAddresses.Count == 0 && GlobalData.WalletStats.Subaddresses.Count > 0)
+                        {
+                            walletVm.WalletAddresses = [.. GlobalData.WalletStats.Subaddresses.Values];
+                        }
+                        else
+                        {
+                            // Update existing account fields, only if value changed
+                            // GlobalData.WalletStats.Subaddresses get cleared in asynchronous call so sometimes even though you check if key exists, it will not exist anymore
+                            foreach (Account wallet in walletVm.WalletAddresses)
+                            {
+                                if (GlobalData.WalletStats.Subaddresses.ContainsKey(wallet.Index))
+                                {
+                                    if (!wallet.Label.Equals(GlobalData.WalletStats.Subaddresses[wallet.Index].Label))
+                                    {
+                                        wallet.Label = GlobalData.WalletStats.Subaddresses[wallet.Index].Label;
+                                    }
+                                    if (!wallet.AddressShort.Equals(GlobalData.WalletStats.Subaddresses[wallet.Index].AddressShort))
+                                    {
+                                        wallet.AddressShort = GlobalData.WalletStats.Subaddresses[wallet.Index].AddressShort;
+                                    }
+                                    if (wallet.BalanceTotal != GlobalData.WalletStats.Subaddresses[wallet.Index].BalanceTotal)
+                                    {
+                                        wallet.BalanceTotal = GlobalData.WalletStats.Subaddresses[wallet.Index].BalanceTotal;
+                                    }
+                                    if (wallet.BalanceUnlocked != GlobalData.WalletStats.Subaddresses[wallet.Index].BalanceUnlocked)
+                                    {
+                                        wallet.BalanceUnlocked = GlobalData.WalletStats.Subaddresses[wallet.Index].BalanceUnlocked;
+                                    }
+                                }
+                            }
+
+                            foreach (Account wallet in deleteAccounts)
+                            {
+                                walletVm.WalletAddresses.Remove(wallet);
+                            }
+                            foreach (Account wallet in addAccounts)
+                            {
+                                walletVm.WalletAddresses.Add(wallet);
+                            }
+                        }
+
+                        walletVm.OpenCloseWallet = StatusWallet.CloseWallet;
+
+                        if (mainViewVm.WalletStatus != statusBarMessage)
+                        {
+                            mainViewVm.WalletStatus = statusBarMessage;
+                        }
+                    });
                 }
                 else
                 {
                     // If wallet is closed/was closed by the user, clear fields
-                    if (!string.IsNullOrEmpty(((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).TotalCoins))
-                    {
-                        ((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).TotalCoins = string.Empty;
-                    }
-
-                    if (!string.IsNullOrEmpty(((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).UnlockedCoins))
-                    {
-                        ((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).UnlockedCoins = string.Empty;
-                    }
-
                     string totalLockedLabel = "Total " + GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].DisplayUnits + ":";
-                    if (!((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).TotalLockedLabel.Equals(totalLockedLabel))
-                    {
-                        ((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).TotalLockedLabel = totalLockedLabel;
-                    }
-
                     string totalUnlockedLabel = "Unlocked " + GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].DisplayUnits + ":";
-                    if (!((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).TotalUnlockedLabel.Equals(totalUnlockedLabel))
-                    {
-                        ((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).TotalUnlockedLabel = totalUnlockedLabel;
-                    }
 
-                    if (((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).WalletAddresses.Count != 0)
+                    Dispatcher.UIThread.Invoke(() =>
                     {
-                        ((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).WalletAddresses = [];
-                    }
+                        if (!string.IsNullOrEmpty(walletVm.TotalCoins))
+                        {
+                            walletVm.TotalCoins = string.Empty;
+                        }
+                        if (!string.IsNullOrEmpty(walletVm.UnlockedCoins))
+                        {
+                            walletVm.UnlockedCoins = string.Empty;
+                        }
+                        if (!walletVm.TotalLockedLabel.Equals(totalLockedLabel))
+                        {
+                            walletVm.TotalLockedLabel = totalLockedLabel;
+                        }
+                        if (!walletVm.TotalUnlockedLabel.Equals(totalUnlockedLabel))
+                        {
+                            walletVm.TotalUnlockedLabel = totalUnlockedLabel;
+                        }
+                        if (walletVm.WalletAddresses.Count != 0)
+                        {
+                            walletVm.WalletAddresses = [];
+                        }
 
-                    ((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).OpenCloseWallet = StatusWallet.OpenWallet;
+                        walletVm.OpenCloseWallet = StatusWallet.OpenWallet;
 
-                    // Status Bar
-                    if (((MainViewModel)GlobalData.ViewModelPages[SplitViewPages.MainView]).WalletStatus != GlobalData.WalletClosedMessage)
-                    {
-                        ((MainViewModel)GlobalData.ViewModelPages[SplitViewPages.MainView]).WalletStatus = GlobalData.WalletClosedMessage;
-                    }
+                        if (mainViewVm.WalletStatus != GlobalData.WalletClosedMessage)
+                        {
+                            mainViewVm.WalletStatus = GlobalData.WalletClosedMessage;
+                        }
+                    });
                 }
             }
             catch (Exception ex)
             {
                 Logger.LogException("UIM.UPWV", ex);
-            }      
+            }
         }
 
         public static void UpdateTransfersView()
@@ -573,9 +572,11 @@ namespace NervaOneWalletMiner.Helpers
 
             try
             {
+                TransfersViewModel transfersViewVm = (TransfersViewModel)GlobalData.ViewModelPages[SplitViewPages.Transfers];
+
                 if (GlobalData.IsWalletOpen)
                 {
-                    if (((TransfersViewModel)GlobalData.ViewModelPages[SplitViewPages.Transfers]).Transactions.Count == 0)
+                    if (transfersViewVm.Transactions.Count == 0)
                     {
                         ObservableCollection<Transfer> initialTransfers = [.. GlobalData.TransfersStats.Transactions.Values];
 
@@ -583,37 +584,28 @@ namespace NervaOneWalletMiner.Helpers
                         {
                             Dispatcher.UIThread.Invoke(() =>
                             {
-                                ((TransfersViewModel)GlobalData.ViewModelPages[SplitViewPages.Transfers]).Transactions = [.. initialTransfers.OrderByDescending(t => t.Height)];
+                                transfersViewVm.Transactions = [.. initialTransfers.OrderByDescending(t => t.Height)];
                             });
 
                             // Need to clear transfers AFTER we process them otherwise we might clear them before we process them
                             GlobalData.TransfersStats.Transactions = [];
                         }
 
-                        if (((TransfersViewModel)GlobalData.ViewModelPages[SplitViewPages.Transfers]).Transactions.Count > 0)
+                        if (transfersViewVm.Transactions.Count > 0)
                         {
                             // This will also save after initial open BUT it will cover restoring wallet
-                            newTransfersCount = ((TransfersViewModel)GlobalData.ViewModelPages[SplitViewPages.Transfers]).Transactions.Count;
+                            newTransfersCount = transfersViewVm.Transactions.Count;
                         }
                     }
                     else
                     {
+                        // Compute new transfers on timer thread before marshaling to UI thread
                         List<Transfer> newTransfers = [];
+                        HashSet<string> existingKeys = [.. transfersViewVm.Transactions.Select(t => t.TransactionId + t.Type)];
 
                         foreach (string newTransferKey in GlobalData.TransfersStats.Transactions.Keys)
                         {
-                            // Check if transaction already exists in datagrid and add it to the top if it does not
-                            bool isFound = false;
-                            foreach (Transfer transfer in ((TransfersViewModel)GlobalData.ViewModelPages[SplitViewPages.Transfers]).Transactions)
-                            {
-                                if (transfer.TransactionId + transfer.Type == newTransferKey)
-                                {
-                                    isFound = true;
-                                    break;
-                                }
-                            }
-
-                            if (!isFound)
+                            if (!existingKeys.Contains(newTransferKey))
                             {
                                 newTransfers.Add(GlobalData.TransfersStats.Transactions[newTransferKey]);
                             }
@@ -621,14 +613,16 @@ namespace NervaOneWalletMiner.Helpers
 
                         if (newTransfers.Count > 0)
                         {
-                            foreach (Transfer transfer in newTransfers.OrderBy(t => t.Height))
+                            List<Transfer> ordered = [.. newTransfers.OrderBy(t => t.Height)];
+
+                            Dispatcher.UIThread.Invoke(() =>
                             {
-                                Dispatcher.UIThread.Invoke(() =>
+                                foreach (Transfer transfer in ordered)
                                 {
-                                    ((TransfersViewModel)GlobalData.ViewModelPages[SplitViewPages.Transfers]).Transactions.Insert(0, transfer);
-                                });
-                            }
-                            
+                                    transfersViewVm.Transactions.Insert(0, transfer);
+                                }
+                            });
+
                             // Need to clear transfers AFTER we process them otherwise we might clear them before we process them
                             GlobalData.TransfersStats.Transactions = [];
                             newTransfersCount = newTransfers.Count;
@@ -647,9 +641,12 @@ namespace NervaOneWalletMiner.Helpers
                 else
                 {
                     // If wallet is closed/was closed by the user, clear fields
-                    if (((TransfersViewModel)GlobalData.ViewModelPages[SplitViewPages.Transfers]).Transactions.Count != 0)
+                    if (transfersViewVm.Transactions.Count != 0)
                     {
-                        ((TransfersViewModel)GlobalData.ViewModelPages[SplitViewPages.Transfers]).Transactions = [];
+                        Dispatcher.UIThread.Invoke(() =>
+                        {
+                            transfersViewVm.Transactions = [];
+                        });
                     }
                 }
             }

--- a/NervaOneWalletMiner/Helpers/UIManager.cs
+++ b/NervaOneWalletMiner/Helpers/UIManager.cs
@@ -112,6 +112,7 @@ namespace NervaOneWalletMiner.Helpers
 
             MasterProcess.StartMasterUpdateProcess();
 
+            UpdateCoinIcon(GlobalMethods.GetLogo());
             UpdateDaemonView();
             UpdateStatusBar();
         }
@@ -267,18 +268,6 @@ namespace NervaOneWalletMiner.Helpers
                 {
                     ((MainViewModel)GlobalData.ViewModelPages[SplitViewPages.MainView]).DaemonVersion = version;
                 }
-            }
-        }
-
-        public static Bitmap GetCoinIcon()
-        {
-            if (GlobalData.ViewModelPages.ContainsKey(SplitViewPages.MainView))
-            {
-                return ((MainViewModel)GlobalData.ViewModelPages[SplitViewPages.MainView]).CoinIcon;
-            }
-            else
-            {
-                return GlobalMethods.GetLogo();
             }
         }
 
@@ -884,11 +873,13 @@ namespace NervaOneWalletMiner.Helpers
                         }
                     }
 
+                    MasterProcess._isDaemonDataFresh = true;
                     GlobalData.IsGetAndSetDaemonDataComplete = true;
                 }
             }
             catch (Exception ex)
             {
+                MasterProcess._isDaemonDataFresh = true;
                 GlobalData.IsGetAndSetDaemonDataComplete = true;
                 Logger.LogException("UIM.GSDD", ex);
             }

--- a/NervaOneWalletMiner/Helpers/UIManager.cs
+++ b/NervaOneWalletMiner/Helpers/UIManager.cs
@@ -284,115 +284,106 @@ namespace NervaOneWalletMiner.Helpers
         {
             try
             {
-                // Daemon View
-                ((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).NetHeight = GlobalData.NetworkStats.NetHeight.ToString();
-                ((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).YourHeight = GlobalData.NetworkStats.YourHeight.ToString();
-                ((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).NetHash = GlobalData.NetworkStats.NetHashString;
-                ((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).RunTime = GlobalData.NetworkStats.RunTime;
+                DaemonViewModel vm = (DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon];
 
-                ((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).MinerMessage = GlobalData.NetworkStats.MinerStatus;
-                ((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).YourHash = GlobalData.NetworkStats.YourHash;
-                ((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).BlockTime = GlobalData.NetworkStats.BlockTime;
-                ((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).MiningAddress = GlobalData.NetworkStats.MiningAddress;
-
-
-                if (((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).Connections.Count == 0)
+                // All updates on the UI thread so PropertyChanged events are coalesced into one render pass
+                Dispatcher.UIThread.Invoke(() =>
                 {
-                    ObservableCollection<Connection> initialConnections = [.. GlobalData.NetworkStats.Connections.Values];
+                    vm.NetHeight = GlobalData.NetworkStats.NetHeight.ToString();
+                    vm.YourHeight = GlobalData.NetworkStats.YourHeight.ToString();
+                    vm.NetHash = GlobalData.NetworkStats.NetHashString;
+                    vm.RunTime = GlobalData.NetworkStats.RunTime;
+                    vm.MinerMessage = GlobalData.NetworkStats.MinerStatus;
+                    vm.YourHash = GlobalData.NetworkStats.YourHash;
+                    vm.BlockTime = GlobalData.NetworkStats.BlockTime;
+                    vm.MiningAddress = GlobalData.NetworkStats.MiningAddress;
 
-                    if (initialConnections.Count > 0)
+                    if (GlobalData.NetworkStats.MinerStatus.Equals(StatusMiner.Mining))
                     {
-                        Dispatcher.UIThread.Invoke(() =>
+                        if (vm.StartStopMining.Equals(StatusMiner.StartMining))
                         {
-                            ((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).Connections = [.. initialConnections];
-                        });
-                    }
-                }
-                else
-                {
-                // Trying to avoid loop within a loop
-                List<Connection> deleteConnections = [];
-                HashSet<string> checkedAddresses = [];
-
-
-                    foreach (Connection connection in ((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).Connections)
-                    {
-                        string connectionsKey = connection.Address + connection.IsIncoming;
-                        checkedAddresses.Add(connectionsKey);
-
-                        if (GlobalData.NetworkStats.Connections.ContainsKey(connectionsKey))
-                        {
-                            // Update, only if value changed
-                            if (!connection.Height.Equals(GlobalData.NetworkStats.Connections[connectionsKey].Height))
-                            {
-                                connection.Height = GlobalData.NetworkStats.Connections[connectionsKey].Height;
-                            }
-                            if (!connection.LiveTime.Equals(GlobalData.NetworkStats.Connections[connectionsKey].LiveTime))
-                            {
-                                connection.LiveTime = GlobalData.NetworkStats.Connections[connectionsKey].LiveTime;
-                            }
-                            if (!connection.State.Equals(GlobalData.NetworkStats.Connections[connectionsKey].State))
-                            {
-                                connection.State = GlobalData.NetworkStats.Connections[connectionsKey].State;
-                            }
+                            vm.StartStopMining = StatusMiner.StopMining;
                         }
-                        else
+                        if (vm.IsNumThreadsEnabled)
                         {
-                            // Connections to remove
-                            deleteConnections.Add(connection);
+                            vm.IsNumThreadsEnabled = false;
+                        }
+                    }
+                    else
+                    {
+                        if (vm.StartStopMining.Equals(StatusMiner.StopMining))
+                        {
+                            vm.StartStopMining = StatusMiner.StartMining;
+                        }
+                        if (!vm.IsNumThreadsEnabled)
+                        {
+                            vm.IsNumThreadsEnabled = true;
                         }
                     }
 
-                    foreach (Connection connection in deleteConnections)
+                    if (vm.Connections.Count == 0)
                     {
-                        Dispatcher.UIThread.Invoke(() =>
+                        if (GlobalData.NetworkStats.Connections.Count > 0)
                         {
-                            ((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).Connections.Remove(connection);
-                        });
-                    }
-
-                    foreach (string key in GlobalData.NetworkStats.Connections.Keys)
-                    {
-                        if (!checkedAddresses.Contains(key))
-                        {
-                            // Need to add new wallet
-                            Dispatcher.UIThread.Invoke(() =>
-                            {
-                                ((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).Connections.Add(GlobalData.NetworkStats.Connections[key]);
-                            });
+                            vm.Connections = [.. GlobalData.NetworkStats.Connections.Values];
                         }
                     }
-                }
+                    else
+                    {
+                        List<Connection> deleteConnections = [];
+                        List<Connection> addConnections = [];
+                        HashSet<string> checkedAddresses = [];
 
-                if (GlobalData.NetworkStats.MinerStatus.Equals(StatusMiner.Mining))
-                {
-                    // Mining so disable number of threads and show Stop Mining
-                    if (((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).StartStopMining.Equals(StatusMiner.StartMining))
-                    {
-                        ((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).StartStopMining = StatusMiner.StopMining;
+                        foreach (Connection connection in vm.Connections)
+                        {
+                            string connectionsKey = connection.Address + connection.IsIncoming;
+                            checkedAddresses.Add(connectionsKey);
+
+                            if (GlobalData.NetworkStats.Connections.ContainsKey(connectionsKey))
+                            {
+                                // Update, only if value changed
+                                if (!connection.Height.Equals(GlobalData.NetworkStats.Connections[connectionsKey].Height))
+                                {
+                                    connection.Height = GlobalData.NetworkStats.Connections[connectionsKey].Height;
+                                }
+                                if (!connection.LiveTime.Equals(GlobalData.NetworkStats.Connections[connectionsKey].LiveTime))
+                                {
+                                    connection.LiveTime = GlobalData.NetworkStats.Connections[connectionsKey].LiveTime;
+                                }
+                                if (!connection.State.Equals(GlobalData.NetworkStats.Connections[connectionsKey].State))
+                                {
+                                    connection.State = GlobalData.NetworkStats.Connections[connectionsKey].State;
+                                }
+                            }
+                            else
+                            {
+                                deleteConnections.Add(connection);
+                            }
+                        }
+
+                        foreach (string key in GlobalData.NetworkStats.Connections.Keys)
+                        {
+                            if (!checkedAddresses.Contains(key))
+                            {
+                                addConnections.Add(GlobalData.NetworkStats.Connections[key]);
+                            }
+                        }
+
+                        foreach (Connection connection in deleteConnections)
+                        {
+                            vm.Connections.Remove(connection);
+                        }
+                        foreach (Connection connection in addConnections)
+                        {
+                            vm.Connections.Add(connection);
+                        }
                     }
-                    if (((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).IsNumThreadsEnabled)
-                    {
-                        ((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).IsNumThreadsEnabled = false;
-                    }
-                }
-                else
-                {
-                    // Not mining so enable number of threads and set Start Mining
-                    if (((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).StartStopMining.Equals(StatusMiner.StopMining))
-                    {
-                        ((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).StartStopMining = StatusMiner.StartMining;
-                    }
-                    if (!((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).IsNumThreadsEnabled)
-                    {
-                        ((DaemonViewModel)GlobalData.ViewModelPages[SplitViewPages.Daemon]).IsNumThreadsEnabled = true;
-                    }
-                }
+                });
             }
             catch (Exception ex)
             {
                 Logger.LogException("UIM.UPDV", ex);
-            }          
+            }
         }
 
         public static void UpdateStatusBar()


### PR DESCRIPTION
Fix idle CPU drain caused by Avalonia 11.3 continuous render loops on Windows and Android (software rendering mode, RedirectionSurface)
Reduce Android active CPU usage: 2-second timer, background mode (skip all RPC/UI when screen off), fresh-data gate for daemon view, event-driven coin icon, faster log file locking
Batch all UpdateDaemonView, UpdateWalletView, and UpdateTransfersView UI mutations into single Dispatcher.UIThread.Invoke calls to reduce render passes
Reset timer count on app resume so daemon and wallet data refresh immediately instead of waiting up to 10 seconds