### PR TITLE
Address potential issues identified by code scan. 

### DIFF
--- a/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
+++ b/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
@@ -5,8 +5,8 @@
     <SupportedOSPlatformVersion>26</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ApplicationId>one.nerva.mobile</ApplicationId>
-    <ApplicationVersion>40</ApplicationVersion>
-    <ApplicationDisplayVersion>1.0.40</ApplicationDisplayVersion>
+    <ApplicationVersion>41</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0.41</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidEnableProfiledAot>False</AndroidEnableProfiledAot>
     <RuntimeIdentifiers>android-arm64</RuntimeIdentifiers>

--- a/NervaOneWalletMiner/Helpers/GlobalData.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalData.cs
@@ -16,7 +16,7 @@ namespace NervaOneWalletMiner.Helpers
     {
         public const string AppNameMain = "NervaOne";
         public const string AppNameDesktop = "NervaOneDesktop";
-        public const string Version = "0.8.5.12";
+        public const string Version = "0.8.5.13";
 
         public const string CliToolsDirName = "cli";
         public const string WalletDirName = "wallets";

--- a/NervaOneWalletMiner/Helpers/GlobalMethods.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalMethods.cs
@@ -1149,7 +1149,7 @@ namespace NervaOneWalletMiner.Helpers
                     Logger.LogDebug("GLM.RSQS", "Restarting CLI with QuickSync");
                     ProcessManager.Kill(GlobalData.WalletProcessName);
 
-                    StopAndCloseDaemon();
+                    await Task.Run(() => StopAndCloseDaemon());
 
                     GlobalData.IsDaemonRestarting = true;
                     string quickSyncFile = Path.Combine(GlobalData.CliToolsDir, Path.GetFileName(GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].QuickSyncUrl));

--- a/NervaOneWalletMiner/Helpers/GlobalMethods.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalMethods.cs
@@ -1326,6 +1326,7 @@ namespace NervaOneWalletMiner.Helpers
             GlobalData.NewestTransactionHeight = 0;
             GlobalData.WalletStats = new();
             GlobalData.WalletPassProvidedTime = DateTime.MinValue;
+            GlobalData.WalletPasswordHash = string.Empty;
         }
 
         public static void CoinChanged()

--- a/NervaOneWalletMiner/Helpers/ProcessManager.cs
+++ b/NervaOneWalletMiner/Helpers/ProcessManager.cs
@@ -241,8 +241,6 @@ namespace NervaOneWalletMiner.Helpers
                 Process? process = Process.Start(new ProcessStartInfo(fileName, arguments)
                 {
                     UseShellExecute = false,
-                    RedirectStandardError = true,
-                    RedirectStandardOutput = true,
                     CreateNoWindow = true,
                     WorkingDirectory = GlobalData.CliToolsDir
                 });

--- a/NervaOneWalletMiner/Rpc/Common/HttpHelper.cs
+++ b/NervaOneWalletMiner/Rpc/Common/HttpHelper.cs
@@ -84,7 +84,7 @@ namespace NervaOneWalletMiner.Rpc.Common
             return response;
         }
 
-        public static ServiceError GetHttpError(string source, HttpResponseMessage httpResponse)
+        public static async Task<ServiceError> GetHttpError(string source, HttpResponseMessage httpResponse)
         {
             ServiceError httpError = new();
 
@@ -93,7 +93,7 @@ namespace NervaOneWalletMiner.Rpc.Common
                 httpError.IsError = true;
                 httpError.Code = httpResponse.StatusCode.ToString();
                 httpError.Message = httpResponse.ReasonPhrase;
-                httpError.Content = httpResponse.Content.ReadAsStringAsync().Result;
+                httpError.Content = await httpResponse.Content.ReadAsStringAsync();
 
                 Logger.LogError("HTTP.GHE", source + " - response failed. Code: " + httpResponse.StatusCode + ", Phrase: " + httpResponse.ReasonPhrase);
             }

--- a/NervaOneWalletMiner/Rpc/Daemon/Coins/Dash/DaemonServiceDASH.cs
+++ b/NervaOneWalletMiner/Rpc/Daemon/Coins/Dash/DaemonServiceDASH.cs
@@ -57,13 +57,14 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    if (string.IsNullOrEmpty(httpResponse.Content.ReadAsStringAsync().Result))
+                    string responseContent = await httpResponse.Content.ReadAsStringAsync();
+                    if (string.IsNullOrEmpty(responseContent))
                     {
                         Logger.LogInfo("DAS.DSPD", "Response Content is empty");
                     }
                     else
                     {
-                        JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                        JObject jsonObject = JObject.Parse(responseContent);
 
                         var error = jsonObject["error"];
                         if (error != null)
@@ -81,7 +82,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -114,13 +115,14 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    if (string.IsNullOrEmpty(httpResponse.Content.ReadAsStringAsync().Result))
+                    string responseContent = await httpResponse.Content.ReadAsStringAsync();
+                    if (string.IsNullOrEmpty(responseContent))
                     {
                         Logger.LogInfo("DAS.DGTI", "Response Content is empty");
                     }
                     else
                     {
-                        JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                        JObject jsonObject = JObject.Parse(responseContent);
 
                         var error = jsonObject["error"];
                         if (error != null)
@@ -147,7 +149,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                     responseObj.Status = "ERROR";
                 }
 
@@ -165,13 +167,14 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                     httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
                     if (httpResponse.IsSuccessStatusCode)
                     {
-                        if (string.IsNullOrEmpty(httpResponse.Content.ReadAsStringAsync().Result))
+                        string responseContent = await httpResponse.Content.ReadAsStringAsync();
+                        if (string.IsNullOrEmpty(responseContent))
                         {
                             Logger.LogInfo("DAS.DGTI", "Response Content is empty");
                         }
                         else
                         {
-                            JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                            JObject jsonObject = JObject.Parse(responseContent);
 
                             var error = jsonObject["error"];
                             if (error != null)
@@ -200,7 +203,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                     else
                     {
                         // Set HTTP error
-                        responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                        responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                     }
                 }
 
@@ -218,13 +221,14 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                     httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
                     if (httpResponse.IsSuccessStatusCode)
                     {
-                        if (string.IsNullOrEmpty(httpResponse.Content.ReadAsStringAsync().Result))
+                        string responseContent = await httpResponse.Content.ReadAsStringAsync();
+                        if (string.IsNullOrEmpty(responseContent))
                         {
                             Logger.LogInfo("DAS.DGTI", "Response Content is empty");
                         }
                         else
                         {
-                            JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                            JObject jsonObject = JObject.Parse(responseContent);
 
                             var error = jsonObject["error"];
                             if (error != null)
@@ -242,7 +246,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                     else
                     {
                         // Set HTTP error
-                        responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                        responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                     }
                 }
             }
@@ -288,13 +292,14 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    if (string.IsNullOrEmpty(httpResponse.Content.ReadAsStringAsync().Result))
+                    string responseContent = await httpResponse.Content.ReadAsStringAsync();
+                    if (string.IsNullOrEmpty(responseContent))
                     {
                         Logger.LogInfo("DAS.DGTC", "Response Content is empty");
                     }
                     else
                     {
-                        JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                        JObject jsonObject = JObject.Parse(responseContent);
 
                         var error = jsonObject["error"];
                         if (error != null)
@@ -323,7 +328,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                             }
                             else
                             {
-                                Logger.LogInfo("DAS.DGTC", "Result missing: " + GlobalMethods.RemoveLineBreaksAndSpaces(httpResponse.Content.ReadAsStringAsync().Result));
+                                Logger.LogInfo("DAS.DGTC", "Result missing: " + GlobalMethods.RemoveLineBreaksAndSpaces(responseContent));
                             }
 
                             responseObj.Error.IsError = false;
@@ -333,7 +338,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)

--- a/NervaOneWalletMiner/Rpc/Daemon/Coins/Dash/DaemonServiceDASH.cs
+++ b/NervaOneWalletMiner/Rpc/Daemon/Coins/Dash/DaemonServiceDASH.cs
@@ -136,13 +136,22 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                             // Set successful response
                             isNetInfoSuccess = true;
 
-                            ResGetNetInfo getInfoResponse = JsonConvert.DeserializeObject<ResGetNetInfo>(jsonObject.SelectToken("result")!.ToString())!;
-                            responseObj.ConnectionCountOut = getInfoResponse.outboundconnections;
-                            responseObj.ConnectionCountIn = getInfoResponse.inboundmnconnections;
-                            responseObj.Version = getInfoResponse.buildversion;
-                            responseObj.Status = "OK";
+                            var resultToken = jsonObject.SelectToken("result");
+                            if (resultToken == null)
+                            {
+                                responseObj.Error.IsError = true;
+                                responseObj.Error.Message = "Response missing 'result' field";
+                            }
+                            else
+                            {
+                                ResGetNetInfo getInfoResponse = JsonConvert.DeserializeObject<ResGetNetInfo>(resultToken.ToString())!;
+                                responseObj.ConnectionCountOut = getInfoResponse.outboundconnections;
+                                responseObj.ConnectionCountIn = getInfoResponse.inboundmnconnections;
+                                responseObj.Version = getInfoResponse.buildversion;
+                                responseObj.Status = "OK";
 
-                            responseObj.Error.IsError = false;
+                                responseObj.Error.IsError = false;
+                            }
                         }
                     }
                 }
@@ -183,20 +192,28 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                                 responseObj.Error = GetServiceError(GetCallerName(), error);
                             }
                             else
-                            {
-                                // Set successful response
-                                ResGetMiningInfo getInfoResponse = JsonConvert.DeserializeObject<ResGetMiningInfo>(jsonObject.SelectToken("result")!.ToString())!;
+                            {                                
+                                var resultToken = jsonObject.SelectToken("result");
+                                if (resultToken == null)
+                                {
+                                    responseObj.Error.IsError = true;
+                                    responseObj.Error.Message = "Response missing 'result' field";
+                                }
+                                else
+                                {
+                                    // Set successful response
+                                    ResGetMiningInfo getInfoResponse = JsonConvert.DeserializeObject<ResGetMiningInfo>(resultToken.ToString())!;
+                                    responseObj.Height = getInfoResponse.blocks;
+                                    responseObj.TargetHeight = getInfoResponse.headers;
+                                    responseObj.NetworkHashRate = getInfoResponse.difficulty * 28633552;
 
-                                responseObj.Height = getInfoResponse.blocks;
-                                responseObj.TargetHeight = getInfoResponse.headers;                                                              
-                                responseObj.NetworkHashRate = getInfoResponse.difficulty * 28633552;
-
-                                /*
-                                 * difficulty = hashrate / (2^256 / max_target / intended_time_per_block)
-                                 * = hashrate / (2^256 / (2^208*65535) / 150)
-                                 * = hashrate / (2^48 / 65535 / 150)
-                                 * = hashrate / 28633552.22
-                                 */
+                                    /*
+                                     * difficulty = hashrate / (2^256 / max_target / intended_time_per_block)
+                                     * = hashrate / (2^256 / (2^208*65535) / 150)
+                                     * = hashrate / (2^48 / 65535 / 150)
+                                     * = hashrate / 28633552.22
+                                     */
+                                }
                             }
                         }
                     }
@@ -309,10 +326,11 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                         }
                         else
                         {
-                            if (jsonObject.SelectToken("result") != null)
+                            var resultToken = jsonObject.SelectToken("result");
+                            if (resultToken != null)
                             {
                                 // Set successful response
-                                List<ResGetConnections> getConnectionsResponse = JsonConvert.DeserializeObject<List<ResGetConnections>>(jsonObject.SelectToken("result")!.ToString())!;
+                                List<ResGetConnections> getConnectionsResponse = JsonConvert.DeserializeObject<List<ResGetConnections>>(resultToken.ToString())!;
 
                                 foreach (ResGetConnections connection in getConnectionsResponse)
                                 {

--- a/NervaOneWalletMiner/Rpc/Daemon/Coins/XmrBased/DaemonServiceBaseXMR.cs
+++ b/NervaOneWalletMiner/Rpc/Daemon/Coins/XmrBased/DaemonServiceBaseXMR.cs
@@ -62,7 +62,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "start_mining"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -84,7 +84,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -110,7 +110,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "stop_mining"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -132,7 +132,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -158,7 +158,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "stop_daemon"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -177,7 +177,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -208,13 +208,14 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    if (string.IsNullOrEmpty(httpResponse.Content.ReadAsStringAsync().Result))
+                    string responseContent = await httpResponse.Content.ReadAsStringAsync();
+                    if (string.IsNullOrEmpty(responseContent))
                     {
                         Logger.LogInfo(CoinPrefix + ".DGTI", "Response Content is empty");
                     }
                     else
                     {
-                        JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                        JObject jsonObject = JObject.Parse(responseContent);
 
                         var error = jsonObject["error"];
                         if (error != null)
@@ -243,7 +244,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -322,13 +323,14 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    if (string.IsNullOrEmpty(httpResponse.Content.ReadAsStringAsync().Result))
+                    string responseContent = await httpResponse.Content.ReadAsStringAsync();
+                    if (string.IsNullOrEmpty(responseContent))
                     {
                         Logger.LogInfo(CoinPrefix + ".DGTC", "Response Content is empty");
                     }
                     else
                     {
-                        JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                        JObject jsonObject = JObject.Parse(responseContent);
 
                         var error = jsonObject["error"];
                         if (error != null)
@@ -357,7 +359,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                             }
                             else
                             {
-                                Logger.LogInfo(CoinPrefix + ".DGTC", "Connections missing: " + GlobalMethods.RemoveLineBreaksAndSpaces(httpResponse.Content.ReadAsStringAsync().Result));
+                                Logger.LogInfo(CoinPrefix + ".DGTC", "Connections missing: " + GlobalMethods.RemoveLineBreaksAndSpaces(responseContent));
                             }
 
                             responseObj.Error.IsError = false;
@@ -367,7 +369,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -423,13 +425,14 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "mining_status"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    if (string.IsNullOrEmpty(httpResponse.Content.ReadAsStringAsync().Result))
+                    string responseContent = await httpResponse.Content.ReadAsStringAsync();
+                    if (string.IsNullOrEmpty(responseContent))
                     {
                         Logger.LogInfo(CoinPrefix + ".DMSS", "Response Content is empty");
                     }
                     else
                     {
-                        JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                        JObject jsonObject = JObject.Parse(responseContent);
 
                         var error = jsonObject["error"];
                         if (error != null)
@@ -453,7 +456,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)

--- a/NervaOneWalletMiner/Rpc/Daemon/Coins/XmrBased/DaemonServiceBaseXMR.cs
+++ b/NervaOneWalletMiner/Rpc/Daemon/Coins/XmrBased/DaemonServiceBaseXMR.cs
@@ -224,20 +224,28 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                             responseObj.Error = GetServiceError(GetCallerName(), error);
                         }
                         else
-                        {
-                            // Set successful response
-                            ResGetInfo getInfoResponse = JsonConvert.DeserializeObject<ResGetInfo>(jsonObject.SelectToken("result")!.ToString())!;
+                        {                            
+                            var resultToken = jsonObject.SelectToken("result");
+                            if (resultToken == null)
+                            {
+                                responseObj.Error.IsError = true;
+                                responseObj.Error.Message = "Response missing 'result' field";
+                            }
+                            else
+                            {
+                                // Set successful response
+                                ResGetInfo getInfoResponse = JsonConvert.DeserializeObject<ResGetInfo>(resultToken.ToString())!;
+                                responseObj.Height = getInfoResponse.height;
+                                responseObj.TargetHeight = getInfoResponse.target_height;
+                                responseObj.NetworkHashRate = (ulong)(getInfoResponse.difficulty / BlockSeconds);
+                                responseObj.ConnectionCountOut = getInfoResponse.outgoing_connections_count;
+                                responseObj.ConnectionCountIn = getInfoResponse.incoming_connections_count;
+                                responseObj.StartTime = GlobalMethods.UnixTimeStampToDateTime(getInfoResponse.start_time);
+                                responseObj.Version = getInfoResponse.version;
+                                responseObj.Status = getInfoResponse.status;
 
-                            responseObj.Height = getInfoResponse.height;
-                            responseObj.TargetHeight = getInfoResponse.target_height;
-                            responseObj.NetworkHashRate = (ulong)(getInfoResponse.difficulty / BlockSeconds);
-                            responseObj.ConnectionCountOut = getInfoResponse.outgoing_connections_count;
-                            responseObj.ConnectionCountIn = getInfoResponse.incoming_connections_count;
-                            responseObj.StartTime = GlobalMethods.UnixTimeStampToDateTime(getInfoResponse.start_time);
-                            responseObj.Version = getInfoResponse.version;
-                            responseObj.Status = getInfoResponse.status;
-
-                            responseObj.Error.IsError = false;
+                                responseObj.Error.IsError = false;
+                            }
                         }
                     }
                 }
@@ -340,10 +348,11 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                         }
                         else
                         {
-                            if (jsonObject.SelectToken("result.connections") != null)
+                            var connectionsToken = jsonObject.SelectToken("result.connections");
+                            if (connectionsToken != null)
                             {
                                 // Set successful response
-                                List<ResGetConnections> getConnectionsResponse = JsonConvert.DeserializeObject<List<ResGetConnections>>(jsonObject.SelectToken("result.connections")!.ToString())!;
+                                List<ResGetConnections> getConnectionsResponse = JsonConvert.DeserializeObject<List<ResGetConnections>>(connectionsToken.ToString())!;
 
                                 foreach (ResGetConnections connection in getConnectionsResponse)
                                 {

--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/Dash/WalletServiceDASH.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/Dash/WalletServiceDASH.cs
@@ -94,7 +94,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -111,7 +111,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -149,7 +149,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -166,7 +166,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -209,7 +209,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -226,7 +226,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -264,7 +264,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -280,7 +280,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -321,7 +321,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -337,7 +337,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -397,7 +397,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -416,7 +416,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -473,7 +473,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -504,7 +504,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
 
                 if (isSuccess)
@@ -522,7 +522,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
                     if (httpResponse.IsSuccessStatusCode)
                     {
-                        JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                        JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                         var error = jsonObject["error"];
                         if (error != null)
@@ -572,7 +572,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     else
                     {
                         // Set HTTP error
-                        responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                        responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                     }
                 }
             }
@@ -620,7 +620,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -654,7 +654,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -693,7 +693,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -733,7 +733,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -776,7 +776,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -793,7 +793,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)

--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/Dash/WalletServiceDASH.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/Dash/WalletServiceDASH.cs
@@ -483,22 +483,30 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     }
                     else
                     {                        
-                        List<WalletAccount> getAccountsResponse = JsonConvert.DeserializeObject<List<WalletAccount>>(jsonObject.SelectToken("result")!.ToString())!;
-                                               
-                        foreach (WalletAccount account in getAccountsResponse)
-                        {
-                            Account newAccount = new()
-                            {
-                                Index = index++,
-                                AddressFull = account.address,
-                                AddressShort = GlobalMethods.GetShorterString(account.address, 12),
-                                Label = account.label
-                            };
-
-                            accountsDictionary.Add(newAccount.AddressFull, newAccount);
+                        var resultToken = jsonObject.SelectToken("result");
+                        if (resultToken == null)
+                        {                            
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result' field";
                         }
+                        else
+                        {
+                            List<WalletAccount> getAccountsResponse = JsonConvert.DeserializeObject<List<WalletAccount>>(resultToken.ToString())!;
+                            foreach (WalletAccount account in getAccountsResponse)
+                            {
+                                Account newAccount = new()
+                                {
+                                    Index = index++,
+                                    AddressFull = account.address,
+                                    AddressShort = GlobalMethods.GetShorterString(account.address, 12),
+                                    Label = account.label
+                                };
 
-                        isSuccess = true;
+                                accountsDictionary.Add(newAccount.AddressFull, newAccount);
+                            }
+
+                            isSuccess = true;
+                        }
                     }
                 }
                 else
@@ -532,41 +540,49 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                         }
                         else
                         {
-                            List<WalletAccount> getAccountsResponse = JsonConvert.DeserializeObject<List<WalletAccount>>(jsonObject.SelectToken("result")!.ToString())!;
-
-                            foreach (WalletAccount account in getAccountsResponse)
+                            var resultToken = jsonObject.SelectToken("result");
+                            if (resultToken == null)
                             {
-                                if(accountsDictionary.ContainsKey(account.address))
+                                responseObj.Error.IsError = true;
+                                responseObj.Error.Message = "Response missing 'result' field";
+                            }
+                            else
+                            {
+                                List<WalletAccount> getAccountsResponse = JsonConvert.DeserializeObject<List<WalletAccount>>(resultToken.ToString())!;
+                                foreach (WalletAccount account in getAccountsResponse)
                                 {
-                                    accountsDictionary[account.address].BalanceTotal = account.amount;
-                                    accountsDictionary[account.address].BalanceUnlocked = account.amount;                                    
-                                }
-                                else
-                                {
-                                    Account newAccount = new()
+                                    if(accountsDictionary.ContainsKey(account.address))
                                     {
-                                        Index = index++,
-                                        AddressFull = account.address,
-                                        AddressShort = GlobalMethods.GetShorterString(account.address, 12),
-                                        BalanceTotal = account.amount,
-                                        BalanceUnlocked = account.amount,                                        
-                                        Label = account.label
-                                    };
+                                        accountsDictionary[account.address].BalanceTotal = account.amount;
+                                        accountsDictionary[account.address].BalanceUnlocked = account.amount;
+                                    }
+                                    else
+                                    {
+                                        Account newAccount = new()
+                                        {
+                                            Index = index++,
+                                            AddressFull = account.address,
+                                            AddressShort = GlobalMethods.GetShorterString(account.address, 12),
+                                            BalanceTotal = account.amount,
+                                            BalanceUnlocked = account.amount,
+                                            Label = account.label
+                                        };
 
-                                    accountsDictionary.Add(newAccount.AddressFull, newAccount);
+                                        accountsDictionary.Add(newAccount.AddressFull, newAccount);
+                                    }
                                 }
+
+                                responseObj.SubAccounts = accountsDictionary.Values.ToList();
+
+                                // Add up total balances
+                                foreach(Account account in responseObj.SubAccounts)
+                                {
+                                    responseObj.BalanceTotal += account.BalanceTotal;
+                                    responseObj.BalanceUnlocked += account.BalanceUnlocked;
+                                }
+
+                                responseObj.Error.IsError = false;
                             }
-
-                            responseObj.SubAccounts = accountsDictionary.Values.ToList();
-
-                            // Add up total balances
-                            foreach(Account account in responseObj.SubAccounts)
-                            {
-                                responseObj.BalanceTotal += account.BalanceTotal;
-                                responseObj.BalanceUnlocked += account.BalanceUnlocked;
-                            }
-
-                            responseObj.Error.IsError = false;
                         }
                     }
                     else
@@ -629,26 +645,35 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                         responseObj.Error = GetServiceError(GetCallerName(), error);
                     }
                     else
-                    {
-                        // Create success response object
-                        List<TransferEntry> getTransfersResponse = JsonConvert.DeserializeObject<List<TransferEntry>>(jsonObject.SelectToken("result.transactions")!.ToString())!;
-                        foreach (TransferEntry entry in getTransfersResponse)
+                    {                        
+                        var resultToken = jsonObject.SelectToken("result.transactions");
+                        if (resultToken == null)
                         {
-                            Transfer newTransfer = new()
-                            {
-                                AccountIndex = -1,
-                                TransactionId = entry.txid,
-                                AddressShort = GlobalMethods.GetShorterString(entry.address, 12),
-                                Height = string.IsNullOrEmpty(entry.blockheight) ? 0 : Convert.ToUInt32(entry.blockheight),
-                                Timestamp = GlobalMethods.UnixTimeStampToDateTime(entry.timereceived).ToLocalTime(),
-                                Amount = Convert.ToDecimal(entry.amount),
-                                Type = GetTransactionType(entry.category)
-                            };
-
-                            responseObj.Transfers.Add(newTransfer);
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result.transactions' field";
                         }
+                        else
+                        {
+                            // Create success response object
+                            List<TransferEntry> getTransfersResponse = JsonConvert.DeserializeObject<List<TransferEntry>>(resultToken.ToString())!;
+                            foreach (TransferEntry entry in getTransfersResponse)
+                            {
+                                Transfer newTransfer = new()
+                                {
+                                    AccountIndex = -1,
+                                    TransactionId = entry.txid,
+                                    AddressShort = GlobalMethods.GetShorterString(entry.address, 12),
+                                    Height = string.IsNullOrEmpty(entry.blockheight) ? 0 : Convert.ToUInt32(entry.blockheight),
+                                    Timestamp = GlobalMethods.UnixTimeStampToDateTime(entry.timereceived).ToLocalTime(),
+                                    Amount = Convert.ToDecimal(entry.amount),
+                                    Type = GetTransactionType(entry.category)
+                                };
 
-                        responseObj.Error.IsError = false;
+                                responseObj.Transfers.Add(newTransfer);
+                            }
+
+                            responseObj.Error.IsError = false;
+                        }
                     }
                 }
                 else
@@ -702,32 +727,40 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                         responseObj.Error = GetServiceError(GetCallerName(), error);
                     }
                     else
-                    {
-                        // Create success response object
-                        TransferEntry getTransfByTxIdResponse = JsonConvert.DeserializeObject<TransferEntry>(jsonObject.SelectToken("result")!.ToString())!;
-                        
-                        responseObj.TransactionId = getTransfByTxIdResponse.txid;                        
-                        responseObj.Height = string.IsNullOrEmpty(getTransfByTxIdResponse.blockheight)? 0 : Convert.ToUInt32(getTransfByTxIdResponse.blockheight);
-                        responseObj.Timestamp = GlobalMethods.UnixTimeStampToDateTime(getTransfByTxIdResponse.timereceived).ToLocalTime();
-                        responseObj.Confirmations = getTransfByTxIdResponse.confirmations;
-                        responseObj.Note = getTransfByTxIdResponse.comment;
-
-                        foreach(TransferDetails details in getTransfByTxIdResponse.Details)
+                    {                        
+                        var resultToken = jsonObject.SelectToken("result");
+                        if (resultToken == null)
                         {
-                            if(decimal.Parse(details.amount, NumberStyles.AllowExponent | NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign) == requestObj.Amount)
-                            {
-                                responseObj.Address = details.address;
-                                responseObj.Type = details.category;
-                                responseObj.Amount = string.IsNullOrEmpty(details.amount) ? 0 : decimal.Parse(details.amount, NumberStyles.AllowExponent | NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign);
-                                responseObj.Fee = string.IsNullOrEmpty(details.fee) ? 0 : decimal.Parse(details.fee, NumberStyles.AllowExponent | NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign);
-                                break;
-                            }
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result' field";
                         }
+                        else
+                        {
+                            // Create success response object
+                            TransferEntry getTransfByTxIdResponse = JsonConvert.DeserializeObject<TransferEntry>(resultToken.ToString())!;
+                            responseObj.TransactionId = getTransfByTxIdResponse.txid;
+                            responseObj.Height = string.IsNullOrEmpty(getTransfByTxIdResponse.blockheight) ? 0 : Convert.ToUInt32(getTransfByTxIdResponse.blockheight);
+                            responseObj.Timestamp = GlobalMethods.UnixTimeStampToDateTime(getTransfByTxIdResponse.timereceived).ToLocalTime();
+                            responseObj.Confirmations = getTransfByTxIdResponse.confirmations;
+                            responseObj.Note = getTransfByTxIdResponse.comment;
 
-                        // TODO: If you want responseObj.Destinations, need to send true for ["verbose"] and try to pick it up that way
-                        //responseObj.Destinations.Add(destination.address + " | " + destination.amount);
+                            foreach(TransferDetails details in getTransfByTxIdResponse.Details)
+                            {
+                                if(decimal.Parse(details.amount, NumberStyles.AllowExponent | NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign) == requestObj.Amount)
+                                {
+                                    responseObj.Address = details.address;
+                                    responseObj.Type = details.category;
+                                    responseObj.Amount = string.IsNullOrEmpty(details.amount) ? 0 : decimal.Parse(details.amount, NumberStyles.AllowExponent | NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign);
+                                    responseObj.Fee = string.IsNullOrEmpty(details.fee) ? 0 : decimal.Parse(details.fee, NumberStyles.AllowExponent | NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign);
+                                    break;
+                                }
+                            }
 
-                        responseObj.Error.IsError = false;
+                            // TODO: If you want responseObj.Destinations, need to send true for ["verbose"] and try to pick it up that way
+                            //responseObj.Destinations.Add(destination.address + " | " + destination.amount);
+
+                            responseObj.Error.IsError = false;
+                        }
                     }
                 }
                 else

--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceBaseXMR.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceBaseXMR.cs
@@ -20,12 +20,13 @@ namespace NervaOneWalletMiner.Rpc.Wallet
     public abstract class WalletServiceBaseXMR : IWalletService
     {
         protected abstract string CoinPrefix { get; }
+        protected virtual decimal CoinAtomicUnits => 1_000_000_000_000m;
 
-        protected virtual decimal AmountFromAtomicUnits(ulong value, int decimalPlaces) =>
-            Math.Round(Convert.ToDecimal(value / 1000000000000.0), decimalPlaces);
+        protected decimal AmountFromAtomicUnits(ulong value, int decimalPlaces) =>
+            Math.Round(Convert.ToDecimal(value / (double)CoinAtomicUnits), decimalPlaces);
 
-        protected virtual ulong AtomicUnitsFromAmount(decimal amount) =>
-            (ulong)(amount * Convert.ToDecimal(1000000000000.0));
+        protected ulong AtomicUnitsFromAmount(decimal amount) =>
+            (ulong)(amount * CoinAtomicUnits);
 
         protected static string GetCallerName([CallerMemberName] string name = "") => name;
 

--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceBaseXMR.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceBaseXMR.cs
@@ -464,13 +464,22 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     }
                     else
                     {
-                        ResRestoreFromSeed createWalletResponse = JsonConvert.DeserializeObject<ResRestoreFromSeed>(jsonObject.SelectToken("result")!.ToString())!;
-                        responseObj.Address = createWalletResponse.address;
-                        responseObj.Seed = createWalletResponse.seed;
-                        responseObj.Info = createWalletResponse.info;
-                        responseObj.WasDeprecated = createWalletResponse.was_deprecated;
+                        var resultToken = jsonObject.SelectToken("result");
+                        if (resultToken == null)
+                        {
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result' field";
+                        }
+                        else
+                        {
+                            ResRestoreFromSeed createWalletResponse = JsonConvert.DeserializeObject<ResRestoreFromSeed>(resultToken.ToString())!;
+                            responseObj.Address = createWalletResponse.address;
+                            responseObj.Seed = createWalletResponse.seed;
+                            responseObj.Info = createWalletResponse.info;
+                            responseObj.WasDeprecated = createWalletResponse.was_deprecated;
 
-                        responseObj.Error.IsError = false;
+                            responseObj.Error.IsError = false;
+                        }
                     }
                 }
                 else
@@ -553,11 +562,20 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     }
                     else
                     {
-                        ResRestoreFromKeys createWalletResponse = JsonConvert.DeserializeObject<ResRestoreFromKeys>(jsonObject.SelectToken("result")!.ToString())!;
-                        responseObj.Address = createWalletResponse.address;
-                        responseObj.Info = createWalletResponse.info;
+                        var resultToken = jsonObject.SelectToken("result");
+                        if (resultToken == null)
+                        {
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result' field";
+                        }
+                        else
+                        {
+                            ResRestoreFromKeys createWalletResponse = JsonConvert.DeserializeObject<ResRestoreFromKeys>(resultToken.ToString())!;
+                            responseObj.Address = createWalletResponse.address;
+                            responseObj.Info = createWalletResponse.info;
 
-                        responseObj.Error.IsError = false;
+                            responseObj.Error.IsError = false;
+                        }
                     }
                 }
                 else
@@ -655,10 +673,19 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     }
                     else
                     {
-                        // We don't use response values
-                        ResTransfer transferResponse = JsonConvert.DeserializeObject<ResTransfer>(jsonObject.SelectToken("result")!.ToString())!;
+                        var resultToken = jsonObject.SelectToken("result");
+                        if (resultToken == null)
+                        {
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result' field";
+                        }
+                        else
+                        {
+                            // We don't use response values
+                            ResTransfer transferResponse = JsonConvert.DeserializeObject<ResTransfer>(resultToken.ToString())!;
 
-                        responseObj.Error.IsError = false;
+                            responseObj.Error.IsError = false;
+                        }
                     }
                 }
                 else
@@ -767,11 +794,20 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                         responseObj.Error = GetServiceError(GetCallerName(), error);
                     }
                     else
-                    {
-                        // We don't use response values
-                        ResTransferSplit transferResponse = JsonConvert.DeserializeObject<ResTransferSplit>(jsonObject.SelectToken("result")!.ToString())!;
+                    {                        
+                        var resultToken = jsonObject.SelectToken("result");
+                        if (resultToken == null)
+                        {
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result' field";
+                        }
+                        else
+                        {
+                            // We don't use response values
+                            ResTransferSplit transferResponse = JsonConvert.DeserializeObject<ResTransferSplit>(resultToken.ToString())!;
 
-                        responseObj.Error.IsError = false;
+                            responseObj.Error.IsError = false;
+                        }
                     }
                 }
                 else
@@ -945,11 +981,20 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     }
                     else
                     {
-                        ResMakeIntegratedAddress createWalletResponse = JsonConvert.DeserializeObject<ResMakeIntegratedAddress>(jsonObject.SelectToken("result")!.ToString())!;
-                        responseObj.IntegratedAddress = createWalletResponse.integrated_address;
-                        responseObj.PaymentId = createWalletResponse.payment_id;
+                        var resultToken = jsonObject.SelectToken("result");
+                        if (resultToken == null)
+                        {
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result' field";
+                        }
+                        else
+                        {
+                            ResMakeIntegratedAddress createWalletResponse = JsonConvert.DeserializeObject<ResMakeIntegratedAddress>(resultToken.ToString())!;
+                            responseObj.IntegratedAddress = createWalletResponse.integrated_address;
+                            responseObj.PaymentId = createWalletResponse.payment_id;
 
-                        responseObj.Error.IsError = false;
+                            responseObj.Error.IsError = false;
+                        }
                     }
                 }
                 else
@@ -1007,26 +1052,35 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     }
                     else
                     {
-                        ResGetAccounts getAccountsResponse = JsonConvert.DeserializeObject<ResGetAccounts>(jsonObject.SelectToken("result")!.ToString())!;
-                        responseObj.BalanceUnlocked = AmountFromAtomicUnits(getAccountsResponse.total_unlocked_balance, 4);
-                        responseObj.BalanceTotal = AmountFromAtomicUnits(getAccountsResponse.total_balance, 4);
-
-                        foreach (WalletAccount account in getAccountsResponse.subaddress_accounts)
+                        var resultToken = jsonObject.SelectToken("result");
+                        if (resultToken == null)
                         {
-                            Account newAccount = new()
-                            {
-                                Index = account.account_index,
-                                Label = account.label,
-                                AddressFull = account.base_address,
-                                AddressShort = GlobalMethods.GetShorterString(account.base_address, 12),
-                                BalanceTotal = AmountFromAtomicUnits(account.balance, 4),
-                                BalanceUnlocked = AmountFromAtomicUnits(account.unlocked_balance, 4)
-                            };
-
-                            responseObj.SubAccounts.Add(newAccount);
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result' field";
                         }
+                        else
+                        {
+                            ResGetAccounts getAccountsResponse = JsonConvert.DeserializeObject<ResGetAccounts>(resultToken.ToString())!;
+                            responseObj.BalanceUnlocked = AmountFromAtomicUnits(getAccountsResponse.total_unlocked_balance, 4);
+                            responseObj.BalanceTotal = AmountFromAtomicUnits(getAccountsResponse.total_balance, 4);
 
-                        responseObj.Error.IsError = false;
+                            foreach (WalletAccount account in getAccountsResponse.subaddress_accounts)
+                            {
+                                Account newAccount = new()
+                                {
+                                    Index = account.account_index,
+                                    Label = account.label,
+                                    AddressFull = account.base_address,
+                                    AddressShort = GlobalMethods.GetShorterString(account.base_address, 12),
+                                    BalanceTotal = AmountFromAtomicUnits(account.balance, 4),
+                                    BalanceUnlocked = AmountFromAtomicUnits(account.unlocked_balance, 4)
+                                };
+
+                                responseObj.SubAccounts.Add(newAccount);
+                            }
+
+                            responseObj.Error.IsError = false;
+                        }
                     }
                 }
                 else
@@ -1119,58 +1173,67 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                         responseObj.Error = GetServiceError(GetCallerName(), error);
                     }
                     else
-                    {
-                        // Create success response object
-                        ResGetTransfers getTransfersResponse = JsonConvert.DeserializeObject<ResGetTransfers>(jsonObject.SelectToken("result")!.ToString())!;
-                        foreach (TransferEntry entry in getTransfersResponse.In)
+                    {                        
+                        var resultToken = jsonObject.SelectToken("result");
+                        if (resultToken == null)
                         {
-                            Transfer newTransfer = new()
-                            {
-                                AccountIndex = entry.subaddr_index.major,
-                                TransactionId = entry.txid,
-                                AddressShort = GlobalMethods.GetShorterString(entry.address, 12),
-                                Height = entry.height,
-                                Timestamp = GlobalMethods.UnixTimeStampToDateTime(entry.timestamp).ToLocalTime(),
-                                Amount = AmountFromAtomicUnits(entry.amount, 4),
-                                Type = entry.type
-                            };
-
-                            responseObj.Transfers.Add(newTransfer);
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result' field";
                         }
-
-                        foreach (TransferEntry entry in getTransfersResponse.Out)
+                        else
                         {
-                            Transfer newTransfer = new()
+                            // Create success response object
+                            ResGetTransfers getTransfersResponse = JsonConvert.DeserializeObject<ResGetTransfers>(resultToken.ToString())!;
+                            foreach (TransferEntry entry in getTransfersResponse.In)
                             {
-                                AccountIndex = entry.subaddr_index.major,
-                                TransactionId = entry.txid,
-                                AddressShort = GlobalMethods.GetShorterString(entry.address, 12),
-                                Height = entry.height,
-                                Timestamp = GlobalMethods.UnixTimeStampToDateTime(entry.timestamp).ToLocalTime(),
-                                Amount = AmountFromAtomicUnits(entry.amount, 4),
-                                Type = entry.type
-                            };
+                                Transfer newTransfer = new()
+                                {
+                                    AccountIndex = entry.subaddr_index.major,
+                                    TransactionId = entry.txid,
+                                    AddressShort = GlobalMethods.GetShorterString(entry.address, 12),
+                                    Height = entry.height,
+                                    Timestamp = GlobalMethods.UnixTimeStampToDateTime(entry.timestamp).ToLocalTime(),
+                                    Amount = AmountFromAtomicUnits(entry.amount, 4),
+                                    Type = entry.type
+                                };
 
-                            responseObj.Transfers.Add(newTransfer);
-                        }
+                                responseObj.Transfers.Add(newTransfer);
+                            }
 
-                        foreach (TransferEntry entry in getTransfersResponse.pending)
-                        {
-                            Transfer newTransfer = new()
+                            foreach (TransferEntry entry in getTransfersResponse.Out)
                             {
-                                AccountIndex = entry.subaddr_index.major,
-                                TransactionId = entry.txid,
-                                AddressShort = GlobalMethods.GetShorterString(entry.address, 12),
-                                Height = entry.height,
-                                Timestamp = GlobalMethods.UnixTimeStampToDateTime(entry.timestamp).ToLocalTime(),
-                                Amount = AmountFromAtomicUnits(entry.amount, 4),
-                                Type = entry.type
-                            };
+                                Transfer newTransfer = new()
+                                {
+                                    AccountIndex = entry.subaddr_index.major,
+                                    TransactionId = entry.txid,
+                                    AddressShort = GlobalMethods.GetShorterString(entry.address, 12),
+                                    Height = entry.height,
+                                    Timestamp = GlobalMethods.UnixTimeStampToDateTime(entry.timestamp).ToLocalTime(),
+                                    Amount = AmountFromAtomicUnits(entry.amount, 4),
+                                    Type = entry.type
+                                };
 
-                            responseObj.Transfers.Add(newTransfer);
+                                responseObj.Transfers.Add(newTransfer);
+                            }
+
+                            foreach (TransferEntry entry in getTransfersResponse.pending)
+                            {
+                                Transfer newTransfer = new()
+                                {
+                                    AccountIndex = entry.subaddr_index.major,
+                                    TransactionId = entry.txid,
+                                    AddressShort = GlobalMethods.GetShorterString(entry.address, 12),
+                                    Height = entry.height,
+                                    Timestamp = GlobalMethods.UnixTimeStampToDateTime(entry.timestamp).ToLocalTime(),
+                                    Amount = AmountFromAtomicUnits(entry.amount, 4),
+                                    Type = entry.type
+                                };
+
+                                responseObj.Transfers.Add(newTransfer);
+                            }
+
+                            responseObj.Error.IsError = false;
                         }
-
-                        responseObj.Error.IsError = false;
                     }
                 }
                 else
@@ -1238,31 +1301,40 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     }
                     else
                     {
-                        // Create success response object
-                        ResGetTransferById getTransfByTxIdResponse = JsonConvert.DeserializeObject<ResGetTransferById>(jsonObject.SelectToken("result")!.ToString())!;
-                        responseObj.Address = getTransfByTxIdResponse.transfer.address;
-                        responseObj.TransactionId = getTransfByTxIdResponse.transfer.txid;
-                        responseObj.PaymentId = getTransfByTxIdResponse.transfer.payment_id;
-                        responseObj.Type = getTransfByTxIdResponse.transfer.type;
-                        responseObj.Height = getTransfByTxIdResponse.transfer.height;
-                        responseObj.Timestamp = GlobalMethods.UnixTimeStampToDateTime(getTransfByTxIdResponse.transfer.timestamp).ToLocalTime();
-                        responseObj.Amount = AmountFromAtomicUnits(getTransfByTxIdResponse.transfer.amount, 6);
-                        responseObj.Fee = AmountFromAtomicUnits(getTransfByTxIdResponse.transfer.fee, 6);
-                        responseObj.Note = getTransfByTxIdResponse.transfer.note;
-                        responseObj.Confirmations = getTransfByTxIdResponse.transfer.confirmations;
-
-                        foreach (TransferDestination destination in getTransfByTxIdResponse.transfer.destinations)
+                        var resultToken = jsonObject.SelectToken("result");
+                        if (resultToken == null)
                         {
-                            responseObj.Destinations.Add(destination.address + " | " + AmountFromAtomicUnits(destination.amount, 6));
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result' field";
                         }
+                        else
+                        {
+                            // Create success response object
+                            ResGetTransferById getTransfByTxIdResponse = JsonConvert.DeserializeObject<ResGetTransferById>(resultToken.ToString())!;
+                            responseObj.Address = getTransfByTxIdResponse.transfer.address;
+                            responseObj.TransactionId = getTransfByTxIdResponse.transfer.txid;
+                            responseObj.PaymentId = getTransfByTxIdResponse.transfer.payment_id;
+                            responseObj.Type = getTransfByTxIdResponse.transfer.type;
+                            responseObj.Height = getTransfByTxIdResponse.transfer.height;
+                            responseObj.Timestamp = GlobalMethods.UnixTimeStampToDateTime(getTransfByTxIdResponse.transfer.timestamp).ToLocalTime();
+                            responseObj.Amount = AmountFromAtomicUnits(getTransfByTxIdResponse.transfer.amount, 6);
+                            responseObj.Fee = AmountFromAtomicUnits(getTransfByTxIdResponse.transfer.fee, 6);
+                            responseObj.Note = getTransfByTxIdResponse.transfer.note;
+                            responseObj.Confirmations = getTransfByTxIdResponse.transfer.confirmations;
 
-                        // There is also transfers but it seems to have the same info. Can you have more than 1 transfer for given transaction id?
-                        //foreach (TransferEntry entry in getTransfByTxIdResponse.transfers)
-                        //{
+                            foreach (TransferDestination destination in getTransfByTxIdResponse.transfer.destinations)
+                            {
+                                responseObj.Destinations.Add(destination.address + " | " + AmountFromAtomicUnits(destination.amount, 6));
+                            }
 
-                        //}
+                            // There is also transfers but it seems to have the same info. Can you have more than 1 transfer for given transaction id?
+                            //foreach (TransferEntry entry in getTransfByTxIdResponse.transfers)
+                            //{
 
-                        responseObj.Error.IsError = false;
+                            //}
+
+                            responseObj.Error.IsError = false;
+                        }
                     }
                 }
                 else
@@ -1316,10 +1388,19 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     }
                     else
                     {
-                        ResGetHeight getHeightResponse = JsonConvert.DeserializeObject<ResGetHeight>(jsonObject.SelectToken("result")!.ToString())!;
-                        responseObj.Height = getHeightResponse.height;
+                        var resultToken = jsonObject.SelectToken("result");
+                        if (resultToken == null)
+                        {
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result' field";
+                        }
+                        else
+                        {
+                            ResGetHeight getHeightResponse = JsonConvert.DeserializeObject<ResGetHeight>(resultToken.ToString())!;
+                            responseObj.Height = getHeightResponse.height;
 
-                        responseObj.Error.IsError = false;
+                            responseObj.Error.IsError = false;
+                        }
                     }
                 }
                 else
@@ -1392,49 +1473,67 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     }
                     else
                     {
-                        ResQueryKey queryKeyResponse = JsonConvert.DeserializeObject<ResQueryKey>(jsonObject.SelectToken("result")!.ToString())!;
-                        if (requestObj.KeyType == KeyType.Mnemonic)
+                        var resultToken = jsonObject.SelectToken("result");
+                        if (resultToken == null)
                         {
-                            responseObj.Mnemonic = queryKeyResponse.key.ToCharArray();
-
-                            responseObj.Error.IsError = false;
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result' field";
                         }
-                        else if (requestObj.KeyType == KeyType.AllViewSpend)
+                        else
                         {
-                            responseObj.PrivateViewKey = queryKeyResponse.key.ToCharArray();
-
-                            // Call again to get spend key
-                            requestJson = new JObject
+                            ResQueryKey queryKeyResponse = JsonConvert.DeserializeObject<ResQueryKey>(resultToken.ToString())!;
+                            if (requestObj.KeyType == KeyType.Mnemonic)
                             {
-                                ["jsonrpc"] = "2.0",
-                                ["id"] = "0",
-                                ["method"] = "query_key",
-                                ["params"] = new JObject() { ["key_type"] = "spend_key" }
-                            };
+                                responseObj.Mnemonic = queryKeyResponse.key.ToCharArray();
 
-                            httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
-                            if (httpResponse.IsSuccessStatusCode)
+                                responseObj.Error.IsError = false;
+                            }
+                            else if (requestObj.KeyType == KeyType.AllViewSpend)
                             {
-                                jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
+                                responseObj.PrivateViewKey = queryKeyResponse.key.ToCharArray();
 
-                                error = jsonObject["error"];
-                                if (error != null)
+                                // Call again to get spend key
+                                requestJson = new JObject
                                 {
-                                    // Set Service error
-                                    responseObj.Error = GetServiceError(GetCallerName(), error);
+                                    ["jsonrpc"] = "2.0",
+                                    ["id"] = "0",
+                                    ["method"] = "query_key",
+                                    ["params"] = new JObject() { ["key_type"] = "spend_key" }
+                                };
+
+                                httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                                if (httpResponse.IsSuccessStatusCode)
+                                {
+                                    jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
+
+                                    error = jsonObject["error"];
+                                    if (error != null)
+                                    {
+                                        // Set Service error
+                                        responseObj.Error = GetServiceError(GetCallerName(), error);
+                                    }
+                                    else
+                                    {
+                                        var spendKeyToken = jsonObject.SelectToken("result");
+                                        if (spendKeyToken == null)
+                                        {
+                                            responseObj.Error.IsError = true;
+                                            responseObj.Error.Message = "Response missing 'result' field";
+                                        }
+                                        else
+                                        {
+                                            queryKeyResponse = JsonConvert.DeserializeObject<ResQueryKey>(spendKeyToken.ToString())!;
+                                            responseObj.PrivateSpendKey = queryKeyResponse.key.ToCharArray();
+
+                                            responseObj.Error.IsError = false;
+                                        }
+                                    }
                                 }
                                 else
                                 {
-                                    queryKeyResponse = JsonConvert.DeserializeObject<ResQueryKey>(jsonObject.SelectToken("result")!.ToString())!;
-                                    responseObj.PrivateSpendKey = queryKeyResponse.key.ToCharArray();
-
-                                    responseObj.Error.IsError = false;
+                                    // Set HTTP error
+                                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                                 }
-                            }
-                            else
-                            {
-                                // Set HTTP error
-                                responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                             }
                         }
                     }
@@ -1506,92 +1605,101 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     {
                         List<ExportObject> exportList = [];
 
-                        // Create success response object
-                        ResGetTransfers getTransfersResponse = JsonConvert.DeserializeObject<ResGetTransfers>(jsonObject.SelectToken("result")!.ToString())!;
-                        foreach (TransferEntry entry in getTransfersResponse.In)
+                        var resultToken = jsonObject.SelectToken("result");
+                        if (resultToken == null)
                         {
-                            ExportObject newTransfer = new()
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result' field";
+                        }
+                        else
+                        {
+                            // Create success response object
+                            ResGetTransfers getTransfersResponse = JsonConvert.DeserializeObject<ResGetTransfers>(resultToken.ToString())!;
+                            foreach (TransferEntry entry in getTransfersResponse.In)
                             {
-                                Address = entry.address,
-                                Height = entry.height.ToString(),
-                                Type = entry.type,
-                                TimeStamp = GlobalMethods.UnixTimeStampToDateTime(entry.timestamp),
-                                Amount = AmountFromAtomicUnits(entry.amount, 12),
-                                TransactionId = entry.txid,
-                                PaymentId = entry.payment_id,
-                                Fee = AmountFromAtomicUnits(entry.fee, 12),
-                                Note = entry.note
-                            };
-
-                            string destinations = string.Empty;
-                            foreach (TransferDestination destination in entry.destinations)
-                            {
-                                if (!string.IsNullOrEmpty(destinations))
+                                ExportObject newTransfer = new()
                                 {
-                                    destinations += ",";
+                                    Address = entry.address,
+                                    Height = entry.height.ToString(),
+                                    Type = entry.type,
+                                    TimeStamp = GlobalMethods.UnixTimeStampToDateTime(entry.timestamp),
+                                    Amount = AmountFromAtomicUnits(entry.amount, 12),
+                                    TransactionId = entry.txid,
+                                    PaymentId = entry.payment_id,
+                                    Fee = AmountFromAtomicUnits(entry.fee, 12),
+                                    Note = entry.note
+                                };
+
+                                string destinations = string.Empty;
+                                foreach (TransferDestination destination in entry.destinations)
+                                {
+                                    if (!string.IsNullOrEmpty(destinations))
+                                    {
+                                        destinations += ",";
+                                    }
+                                    destinations += destination.address;
                                 }
-                                destinations += destination.address;
+
+                                newTransfer.Destination = destinations;
+                                exportList.Add(newTransfer);
                             }
 
-                            newTransfer.Destination = destinations;
-                            exportList.Add(newTransfer);
-                        }
-
-                        foreach (TransferEntry entry in getTransfersResponse.Out)
-                        {
-                            ExportObject newTransfer = new()
+                            foreach (TransferEntry entry in getTransfersResponse.Out)
                             {
-                                Address = entry.address,
-                                Height = entry.height.ToString(),
-                                Type = entry.type,
-                                TimeStamp = GlobalMethods.UnixTimeStampToDateTime(entry.timestamp),
-                                Amount = AmountFromAtomicUnits(entry.amount, 12),
-                                TransactionId = entry.txid,
-                                PaymentId = entry.payment_id,
-                                Fee = AmountFromAtomicUnits(entry.fee, 12),
-                                Note = entry.note
-                            };
-
-                            string destinations = string.Empty;
-                            foreach (TransferDestination destination in entry.destinations)
-                            {
-                                if (!string.IsNullOrEmpty(destinations))
+                                ExportObject newTransfer = new()
                                 {
-                                    destinations += ",";
+                                    Address = entry.address,
+                                    Height = entry.height.ToString(),
+                                    Type = entry.type,
+                                    TimeStamp = GlobalMethods.UnixTimeStampToDateTime(entry.timestamp),
+                                    Amount = AmountFromAtomicUnits(entry.amount, 12),
+                                    TransactionId = entry.txid,
+                                    PaymentId = entry.payment_id,
+                                    Fee = AmountFromAtomicUnits(entry.fee, 12),
+                                    Note = entry.note
+                                };
+
+                                string destinations = string.Empty;
+                                foreach (TransferDestination destination in entry.destinations)
+                                {
+                                    if (!string.IsNullOrEmpty(destinations))
+                                    {
+                                        destinations += ",";
+                                    }
+                                    destinations += destination.address;
                                 }
-                                destinations += destination.address;
+
+                                newTransfer.Destination = destinations;
+                                exportList.Add(newTransfer);
                             }
 
-                            newTransfer.Destination = destinations;
-                            exportList.Add(newTransfer);
+                            // Header row
+                            exportBuilder.AppendLine("height,type,timestamp,amount,fee,running balance,address,transaction id,payment id,destination,note");
+
+                            // Transactions
+                            decimal runningBalance = 0;
+                            foreach (ExportObject transfer in exportList.OrderBy(x => x.TimeStamp))
+                            {
+                                runningBalance += (transfer.Type == TransferType.Out ? -1 * (transfer.Amount + transfer.Fee) : transfer.Amount);
+
+                                exportBuilder.AppendLine(
+                                    transfer.Height + "," +
+                                    transfer.Type + "," +
+                                    transfer.TimeStamp.ToString() + "," +
+                                    transfer.Amount.ToString("F12") + "," +
+                                    transfer.Fee.ToString("F12") + "," +
+                                    runningBalance.ToString("F12") + "," +
+                                    transfer.Address + "," +
+                                    transfer.TransactionId + "," +
+                                    transfer.PaymentId + "," +
+                                    "\"" + transfer.Destination + "\"," +
+                                    "\"" + transfer.Note + "\""
+                                );
+                            }
+
+                            responseObj.ExportString = exportBuilder.ToString();
+                            responseObj.Error.IsError = false;
                         }
-
-                        // Header row
-                        exportBuilder.AppendLine("height,type,timestamp,amount,fee,running balance,address,transaction id,payment id,destination,note");
-
-                        // Transactions
-                        decimal runningBalance = 0;
-                        foreach (ExportObject transfer in exportList.OrderBy(x => x.TimeStamp))
-                        {
-                            runningBalance += (transfer.Type == TransferType.Out ? -1 * (transfer.Amount + transfer.Fee) : transfer.Amount);
-
-                            exportBuilder.AppendLine(
-                                transfer.Height + "," +
-                                transfer.Type + "," +
-                                transfer.TimeStamp.ToString() + "," +
-                                transfer.Amount.ToString("F12") + "," +
-                                transfer.Fee.ToString("F12") + "," +
-                                runningBalance.ToString("F12") + "," +
-                                transfer.Address + "," +
-                                transfer.TransactionId + "," +
-                                transfer.PaymentId + "," +
-                                "\"" + transfer.Destination + "\"," +
-                                "\"" + transfer.Note + "\""
-                            );
-                        }
-
-                        responseObj.ExportString = exportBuilder.ToString();
-                        responseObj.Error.IsError = false;
                     }
                 }
                 else

--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceBaseXMR.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceBaseXMR.cs
@@ -101,7 +101,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -118,7 +118,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -156,7 +156,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -173,7 +173,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -217,7 +217,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -234,7 +234,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -278,7 +278,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -295,7 +295,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -337,7 +337,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -353,7 +353,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -384,7 +384,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -401,7 +401,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -454,7 +454,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -476,7 +476,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -543,7 +543,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -563,7 +563,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -645,7 +645,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -664,7 +664,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -758,7 +758,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -777,7 +777,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -823,7 +823,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -840,7 +840,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -876,7 +876,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -893,7 +893,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -935,7 +935,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -955,7 +955,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -997,7 +997,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -1032,7 +1032,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -1110,7 +1110,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -1176,7 +1176,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -1228,7 +1228,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -1268,7 +1268,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -1306,7 +1306,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -1325,7 +1325,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -1382,7 +1382,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -1415,7 +1415,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                             httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                             if (httpResponse.IsSuccessStatusCode)
                             {
-                                jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                                jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                                 error = jsonObject["error"];
                                 if (error != null)
@@ -1434,7 +1434,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                             else
                             {
                                 // Set HTTP error
-                                responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                                responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                             }
                         }
                     }
@@ -1442,7 +1442,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -1494,7 +1494,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -1597,7 +1597,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -1659,7 +1659,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 Logger.LogDebug(CoinPrefix + ".SWBL", "sweep_all returned.");
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -1673,7 +1673,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 }
                 else
                 {
-                    responseObj.Error = HttpHelper.GetHttpError(GetCallerName(), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(GetCallerName(), httpResponse);
                 }
             }
             catch (Exception ex)

--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceWOW.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceWOW.cs
@@ -1,16 +1,9 @@
-using System;
-
 namespace NervaOneWalletMiner.Rpc.Wallet
 {
     // Wownero implementation as of 5/10/24: https://git.wownero.com/wownero/wownero
     public class WalletServiceWOW : WalletServiceBaseXMR
     {
         protected override string CoinPrefix => "WOW";
-
-        protected override decimal AmountFromAtomicUnits(ulong value, int decimalPlaces) =>
-            Math.Round(Convert.ToDecimal(value / 100000000000.0), decimalPlaces);
-
-        protected override ulong AtomicUnitsFromAmount(decimal amount) =>
-            (ulong)(amount * Convert.ToDecimal(100000000000.0));
+        protected override decimal CoinAtomicUnits => 100_000_000_000m;
     }
 }

--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceXNV.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceXNV.cs
@@ -56,7 +56,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -78,7 +78,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(nameof(RestoreFromSeed), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(nameof(RestoreFromSeed), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -140,7 +140,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -160,7 +160,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(nameof(RestoreFromKeys), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(nameof(RestoreFromKeys), httpResponse);
                 }
             }
             catch (Exception ex)
@@ -218,7 +218,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
-                    JObject jsonObject = JObject.Parse(httpResponse.Content.ReadAsStringAsync().Result);
+                    JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
 
                     var error = jsonObject["error"];
                     if (error != null)
@@ -241,7 +241,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 else
                 {
                     // Set HTTP error
-                    responseObj.Error = HttpHelper.GetHttpError(nameof(GetPrivateKeys), httpResponse);
+                    responseObj.Error = await HttpHelper.GetHttpError(nameof(GetPrivateKeys), httpResponse);
                 }
             }
             catch (Exception ex)

--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceXNV.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceXNV.cs
@@ -66,13 +66,22 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     }
                     else
                     {
-                        ResRestoreFromSeed createWalletResponse = JsonConvert.DeserializeObject<ResRestoreFromSeed>(jsonObject.SelectToken("result")!.ToString())!;
-                        responseObj.Address = createWalletResponse.address;
-                        responseObj.Seed = createWalletResponse.seed;
-                        responseObj.Info = createWalletResponse.info;
-                        responseObj.WasDeprecated = createWalletResponse.was_deprecated;
+                        var resultToken = jsonObject.SelectToken("result");
+                        if (resultToken == null)
+                        {
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result' field";
+                        }
+                        else
+                        {
+                            ResRestoreFromSeed createWalletResponse = JsonConvert.DeserializeObject<ResRestoreFromSeed>(resultToken.ToString())!;
+                            responseObj.Address = createWalletResponse.address;
+                            responseObj.Seed = createWalletResponse.seed;
+                            responseObj.Info = createWalletResponse.info;
+                            responseObj.WasDeprecated = createWalletResponse.was_deprecated;
 
-                        responseObj.Error.IsError = false;
+                            responseObj.Error.IsError = false;
+                        }
                     }
                 }
                 else
@@ -150,11 +159,20 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     }
                     else
                     {
-                        ResRestoreFromKeys createWalletResponse = JsonConvert.DeserializeObject<ResRestoreFromKeys>(jsonObject.SelectToken("result")!.ToString())!;
-                        responseObj.Address = createWalletResponse.address;
-                        responseObj.Info = createWalletResponse.info;
+                        var resultToken = jsonObject.SelectToken("result");
+                        if (resultToken == null)
+                        {
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result' field";
+                        }
+                        else
+                        {
+                            ResRestoreFromKeys createWalletResponse = JsonConvert.DeserializeObject<ResRestoreFromKeys>(resultToken.ToString())!;
+                            responseObj.Address = createWalletResponse.address;
+                            responseObj.Info = createWalletResponse.info;
 
-                        responseObj.Error.IsError = false;
+                            responseObj.Error.IsError = false;
+                        }
                     }
                 }
                 else
@@ -228,14 +246,23 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     }
                     else
                     {
-                        ResQueryKey queryKeyResponse = JsonConvert.DeserializeObject<ResQueryKey>(jsonObject.SelectToken("result")!.ToString())!;
-                        responseObj.PublicViewKey = queryKeyResponse.public_view_key;
-                        responseObj.PrivateViewKey = queryKeyResponse.private_view_key.ToCharArray();
-                        responseObj.PublicSpendKey = queryKeyResponse.public_spend_key;
-                        responseObj.PrivateSpendKey = queryKeyResponse.private_spend_key.ToCharArray();
-                        responseObj.Mnemonic = queryKeyResponse.mnemonic.ToCharArray();
+                        var resultToken = jsonObject.SelectToken("result");
+                        if (resultToken == null)
+                        {
+                            responseObj.Error.IsError = true;
+                            responseObj.Error.Message = "Response missing 'result' field";
+                        }
+                        else
+                        {
+                            ResQueryKey queryKeyResponse = JsonConvert.DeserializeObject<ResQueryKey>(resultToken.ToString())!;
+                            responseObj.PublicViewKey = queryKeyResponse.public_view_key;
+                            responseObj.PrivateViewKey = queryKeyResponse.private_view_key.ToCharArray();
+                            responseObj.PublicSpendKey = queryKeyResponse.public_spend_key;
+                            responseObj.PrivateSpendKey = queryKeyResponse.private_spend_key.ToCharArray();
+                            responseObj.Mnemonic = queryKeyResponse.mnemonic.ToCharArray();
 
-                        responseObj.Error.IsError = false;
+                            responseObj.Error.IsError = false;
+                        }
                     }
                 }
                 else

--- a/NervaOneWalletMiner/ViewModels/DaemonSetupViewModel.cs
+++ b/NervaOneWalletMiner/ViewModels/DaemonSetupViewModel.cs
@@ -279,13 +279,13 @@ namespace NervaOneWalletMiner.ViewModels
             }
         }
 
-        public void RestartWithCommand(string restartOptions)
+        public async void RestartWithCommand(string restartOptions)
         {
             try
             {
                 Logger.LogDebug("DSM.RWCM", "Restarting with command");
                 ProcessManager.Kill(GlobalData.WalletProcessName);
-                GlobalMethods.StopAndCloseDaemon();
+                await Task.Run(() => GlobalMethods.StopAndCloseDaemon());
 
                 if (GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].IsWalletOnly)
                 {
@@ -352,7 +352,7 @@ namespace NervaOneWalletMiner.ViewModels
                 }
 
                 Logger.LogDebug("DSM.PCTU", "Stopping daemon...");
-                GlobalMethods.StopAndCloseDaemon();
+                await Task.Run(() => GlobalMethods.StopAndCloseDaemon());
 
                 GlobalMethods.SetUpCliTools(downloadLink, GlobalData.CliToolsDir);
             }
@@ -394,7 +394,7 @@ namespace NervaOneWalletMiner.ViewModels
                 }
 
                 Logger.LogDebug("DSM.PBDD", "Stopping daemon...");
-                GlobalMethods.StopAndCloseDaemon();
+                await Task.Run(() => GlobalMethods.StopAndCloseDaemon());
 
                 string dataDir = GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].DataDir;
                 string dbSubfolder = GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].BlockchainDbSubfolder;

--- a/NervaOneWalletMiner/Views/CreateWalletView.axaml
+++ b/NervaOneWalletMiner/Views/CreateWalletView.axaml
@@ -41,7 +41,8 @@
 				<TextBox Name="tbxPassword"
 						 Watermark="Enter wallet password"
 						 PasswordChar="*"
-						 RevealPassword="False"/>
+						 RevealPassword="False"
+						 KeyDown="Password_KeyDown"/>
 			</DockPanel>
 
 			<Label Content="Language" Margin="0,15,0,0"/>

--- a/NervaOneWalletMiner/Views/CreateWalletView.axaml.cs
+++ b/NervaOneWalletMiner/Views/CreateWalletView.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using NervaOneWalletMiner.Helpers;
 using NervaOneWalletMiner.Objects.Constants;
@@ -29,17 +30,31 @@ namespace NervaOneWalletMiner.Views
             }
         }
 
+        public void Password_KeyDown(object sender, KeyEventArgs args)
+        {
+            if (args.Key == Key.Enter)
+            {
+                OkButton_Clicked(sender, args);
+            }
+        }
+
         public async void OkButton_Clicked(object sender, RoutedEventArgs args)
         {
             try
             {
-                if (string.IsNullOrEmpty(tbxWalletName.Text) || string.IsNullOrEmpty(tbxPassword.Text))
+                string walletName = tbxWalletName.Text == null ? string.Empty : tbxWalletName.Text;
+
+                if (string.IsNullOrEmpty(walletName) || string.IsNullOrEmpty(tbxPassword.Text))
                 {
                     await DialogService.ShowAsync(new MessageBoxView("Create Wallet", "Wallet Name and Password are required.", true));
                     return;
                 }
+                else if (walletName.Contains('/') || walletName.Contains('\\') || walletName.Contains(".."))
+                {
+                    await DialogService.ShowAsync(new MessageBoxView("Create Wallet", "Wallet Name cannot contain path characters.", true));
+                    return;
+                }
 
-                string walletName = tbxWalletName.Text;
                 char[] walletPassword = tbxPassword.Text.ToCharArray();
                 string walletLanguage = cbxLanguage.SelectedValue == null ? Language.English : cbxLanguage.SelectedValue.ToString()!;
 

--- a/NervaOneWalletMiner/Views/RestoreFromKeysView.axaml
+++ b/NervaOneWalletMiner/Views/RestoreFromKeysView.axaml
@@ -53,7 +53,8 @@
 				<TextBox Name="tbxPassword"
 						 Watermark="Required - new wallet password"
 						 PasswordChar="*"
-						 RevealPassword="False"/>
+						 RevealPassword="False"
+						 KeyDown="Password_KeyDown"/>
 			</DockPanel>
 
 			<Label Content="Language" Margin="0,10,0,0"/>

--- a/NervaOneWalletMiner/Views/RestoreFromKeysView.axaml.cs
+++ b/NervaOneWalletMiner/Views/RestoreFromKeysView.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using NervaOneWalletMiner.Helpers;
 using NervaOneWalletMiner.Objects.Constants;
@@ -28,22 +29,37 @@ namespace NervaOneWalletMiner.Views
             }
         }
 
+        public void Password_KeyDown(object sender, KeyEventArgs args)
+        {
+            if (args.Key == Key.Enter)
+            {
+                OkButton_Clicked(sender, args);
+            }
+        }
+
         public async void OkButton_Clicked(object sender, RoutedEventArgs args)
         {
             try
             {
+                string walletName = tbxWalletName.Text == null ? string.Empty : tbxWalletName.Text;
+
                 if (string.IsNullOrEmpty(tbxWalletAddress.Text)
                     || string.IsNullOrEmpty(tbxViewKey.Text)
                     || string.IsNullOrEmpty(tbxSpendKey.Text)
-                    || string.IsNullOrEmpty(tbxWalletName.Text)
+                    || string.IsNullOrEmpty(walletName)
                     || string.IsNullOrEmpty(tbxPassword.Text))
                 {
                     await DialogService.ShowAsync(new MessageBoxView("Restore From Keys", "Wallet Address, View Key, Spend Key, Wallet Name and Password are all required.", true));
                     return;
                 }
+                else if (walletName.Contains('/') || walletName.Contains('\\') || walletName.Contains(".."))
+                {
+                    await DialogService.ShowAsync(new MessageBoxView("Restore From Keys", "Wallet Name cannot contain path characters.", true));
+                    return;
+                }
 
                 string walletAddress = tbxWalletAddress.Text;
-                string walletName = tbxWalletName.Text;
+
                 char[] viewKey = tbxViewKey.Text.ToCharArray();
                 char[] spendKey = tbxSpendKey.Text.ToCharArray();
                 char[] walletPassword = tbxPassword.Text.ToCharArray();

--- a/NervaOneWalletMiner/Views/RestoreFromSeedView.axaml
+++ b/NervaOneWalletMiner/Views/RestoreFromSeedView.axaml
@@ -52,7 +52,8 @@
 				<TextBox Name="tbxPassword"
 						 Watermark="Required - new wallet password"
 						 PasswordChar="*"
-						 RevealPassword="False"/>
+						 RevealPassword="False"
+						 KeyDown="Password_KeyDown"/>
 			</DockPanel>
 
 			<Label Content="Language" Margin="0,10,0,0"/>

--- a/NervaOneWalletMiner/Views/RestoreFromSeedView.axaml.cs
+++ b/NervaOneWalletMiner/Views/RestoreFromSeedView.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using NervaOneWalletMiner.Helpers;
 using NervaOneWalletMiner.Objects.Constants;
@@ -28,19 +29,33 @@ namespace NervaOneWalletMiner.Views
             }
         }
 
+        public void Password_KeyDown(object sender, KeyEventArgs args)
+        {
+            if (args.Key == Key.Enter)
+            {
+                OkButton_Clicked(sender, args);
+            }
+        }
+
         public async void OkButton_Clicked(object sender, RoutedEventArgs args)
         {
             try
             {
+                string walletName = tbxWalletName.Text == null ? string.Empty : tbxWalletName.Text;
+
                 if (string.IsNullOrEmpty(tbxSeedPhrase.Text)
-                    || string.IsNullOrEmpty(tbxWalletName.Text)
+                    || string.IsNullOrEmpty(walletName)
                     || string.IsNullOrEmpty(tbxPassword.Text))
                 {
                     await DialogService.ShowAsync(new MessageBoxView("Restore From Seed", "Seed Phrase, Wallet Name and Password are all required.", true));
                     return;
                 }
+                else if (walletName.Contains('/') || walletName.Contains('\\') || walletName.Contains(".."))
+                {
+                    await DialogService.ShowAsync(new MessageBoxView("Restore From Seed", "Wallet Name cannot contain path characters.", true));
+                    return;
+                }
 
-                string walletName = tbxWalletName.Text;
                 char[] seed = tbxSeedPhrase.Text.ToCharArray();
                 string seedOffset = tbxSeedOffset.Text ?? string.Empty;
                 char[] walletPassword = tbxPassword.Text.ToCharArray();

--- a/NervaOneWalletMiner/Views/SettingsView.axaml.cs
+++ b/NervaOneWalletMiner/Views/SettingsView.axaml.cs
@@ -6,6 +6,7 @@ using NervaOneWalletMiner.Helpers;
 using NervaOneWalletMiner.Objects.Constants;
 using NervaOneWalletMiner.ViewModels;
 using System;
+using System.Threading.Tasks;
 
 namespace NervaOneWalletMiner.Views
 {
@@ -98,7 +99,7 @@ namespace NervaOneWalletMiner.Views
                         if (GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].StopOnExit)
                         {
                             Logger.LogDebug("SET.SSCL", "Stopping daemon because switching coin and StopOnExit is set");
-                            GlobalMethods.StopAndCloseDaemon();
+                            await Task.Run(() => GlobalMethods.StopAndCloseDaemon());
                         }
                     }
 


### PR DESCRIPTION
### Critical

1. **.Result on async everywhere** — Fixed: replaced all .Result blocking calls with await across all RPC service files, made GetHttpError async.
2. **Null-forgiving ! on SelectToken() results** — Fixed: replaced with explicit null checks; null path sets error state in responseObj, success path in else branch.
3. **Process resource leak** — Fixed: removed RedirectStandardOutput/RedirectStandardError; daemon runs as a fully independent process with no pipe buffer.
4. **RPC credentials in plaintext config** — Left as-is: credentials are auto-generated random 24-char strings, localhost-only, and Dash support is unfinished.
5. **android:debuggable="true" + android:allowBackup in release** — Will be changed before release.

### High

6. **async void fire-and-forget swallows exceptions** — Left as-is: SaveWallet has comprehensive try/catch, concurrent saves guarded by _lastWalletSave timestamp, low practical risk.
7. **Thread.Sleep() blocking (likely UI thread)** — Fixed: UI-path callers wrapped in Task.Run, shutdown and background process paths left synchronous intentionally.
8. **HttpClient.Timeout = InfiniteTimeSpan** — Already addressed: per-request CancellationTokenSource with 50s default, overloads accept custom timeout for long-running operations like sweep.
9. **Hashing.Verify has no segment count check** — Left as-is: both call sites are naturally guarded by wallet-open state; VerifyPasswordLocally catches any exception and returns false.

### Medium

10. **WalletPasswordHash persisted in static global** — Partially addressed: confirmed never persisted to disk; added clear in WalletClosedOrErrored so hash doesn't linger after wallet closes.
11. **No wallet name / path traversal validation** — Fixed: reject names containing /, \ or .. in CreateWallet, RestoreFromSeed and RestoreFromKeys before passing to RPC.
12. **No JSON schema validation before deserialization** — Left as-is: daemon is local and controlled, existing null checks on resultToken cover the main failure case.
13. **Process name matching via .Contains()** — Left as-is: two-level check (ProcessName pre-filter + MainModule.ModuleName) is deliberate cross-platform design; process names specific enough to avoid false positives.
14. **Android service re-started on every Activity recreation** — Left as-is: harmless for this service; CreateNotificationChannel and StartForeground are idempotent, Android ensures a single service instance.

### Low

15. **Full RPC responses logged in cleartext** — Not an issue: only the connections endpoint logs raw response on an error path; wallet endpoints don't log raw responses; HttpHelper debug logs already commented out.
16. **Bare catch (Exception) in 50+ places** — Not an issue: intentional design; all paths log and continue, catching specific types would add no value here.
17. **Platform detection scattered** — Not an issue: IsAndroid(), IsWindows(), IsLinux() are already centralized in GlobalMethods.cs; all call sites use that abstraction.
18. **Atomic unit conversion magic numbers** — Fixed: added CoinAtomicUnits virtual property to WalletServiceBaseXMR (1e12); WalletServiceWOW overrides with its own value (1e11), removing duplicated conversion methods.