### PR TITLE
Add wallet-rpc Digest authentication and fix wallet-only mode restart

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,6 +7,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
     setup:
         runs-on: ubuntu-latest

--- a/.github/workflows/post-artifact-links.yml
+++ b/.github/workflows/post-artifact-links.yml
@@ -1,0 +1,116 @@
+# Posts a comment on the triggering PR with artifact download links once the
+# ci-build workflow completes. Runs as a separate workflow_run-triggered job so
+# that it always executes in the base-repo context and has write access to PR
+# comments - even when the PR comes from a fork, where pull_request-triggered
+# jobs receive a read-only token.
+#
+# NOTE: The suffix list below is coupled to the matrix in dotnet.yml -
+# update both together.
+
+name: Post artifact links
+
+on:
+    workflow_run:
+        workflows: [ci-build]
+        types: [completed]
+
+jobs:
+    post-artifact-links:
+        if: github.event.workflow_run.event == 'pull_request'
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+            -   name: Post artifact links
+                uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+                with:
+                    script: |
+                        const suffixes = [
+                            'win-x64',
+                            'win-arm64',
+                            'linux-x64',
+                            'linux-arm64',
+                            'macos-x64',
+                            'macos-arm64',
+                            'android-arm64',
+                        ];
+
+                        const runId = context.payload.workflow_run.id;
+
+                        const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            run_id: runId,
+                            per_page: 100,
+                        });
+
+                        let succeeded = 0;
+                        let failed = 0;
+
+                        const rows = suffixes.map(suffix => {
+                            const artifact = artifacts.find(a => a.name.endsWith('-' + suffix));
+                            if (artifact) {
+                                succeeded++;
+                                const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/artifacts/${artifact.id}`;
+                                return `| ${artifact.name} | :white_check_mark: | [Download](${url}) |`;
+                            } else {
+                                failed++;
+                                return `| nervaone-${suffix} | :x: | Build failed |`;
+                            }
+                        });
+
+                        const body = [
+                            '<!-- nervaone-artifact-links -->',
+                            '## Build Artifacts',
+                            '',
+                            '| Target | Status | Download |',
+                            '|--------|--------|----------|',
+                            ...rows,
+                            '',
+                            '---',
+                            `*${succeeded} succeeded, ${failed} failed* | [View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId})`,
+                        ].join('\n');
+
+                        if (!context.payload.workflow_run.head_repository) {
+                            core.warning('head_repository is null (fork deleted?); skipping comment.');
+                            return;
+                        }
+                        const headOwner = context.payload.workflow_run.head_repository.owner.login;
+                        const headBranch = context.payload.workflow_run.head_branch;
+                        const headSha = context.payload.workflow_run.head_sha;
+                        const { data: prs } = await github.rest.pulls.list({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            state: 'open',
+                            head: `${headOwner}:${headBranch}`,
+                        });
+                        const pr = prs.find(p => p.head.sha === headSha);
+                        if (!pr) {
+                            core.warning('No open pull request found for this commit; skipping comment.');
+                            return;
+                        }
+                        const prNumber = pr.number;
+
+                        const { data: comments } = await github.rest.issues.listComments({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            issue_number: prNumber,
+                            per_page: 100,
+                        });
+
+                        const existing = comments.find(c => c.body.includes('<!-- nervaone-artifact-links -->'));
+                        if (existing) {
+                            await github.rest.issues.updateComment({
+                                owner: context.repo.owner,
+                                repo: context.repo.repo,
+                                comment_id: existing.id,
+                                body,
+                            });
+                        } else {
+                            await github.rest.issues.createComment({
+                                owner: context.repo.owner,
+                                repo: context.repo.repo,
+                                issue_number: prNumber,
+                                body,
+                            });
+                        }

--- a/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
+++ b/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
@@ -5,8 +5,8 @@
     <SupportedOSPlatformVersion>26</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ApplicationId>one.nerva.android</ApplicationId>
-    <ApplicationVersion>1104</ApplicationVersion>
-    <ApplicationDisplayVersion>1.1.4</ApplicationDisplayVersion>
+    <ApplicationVersion>1105</ApplicationVersion>
+    <ApplicationDisplayVersion>1.1.5</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidEnableProfiledAot>False</AndroidEnableProfiledAot>
     <RuntimeIdentifiers>android-arm64</RuntimeIdentifiers>

--- a/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
+++ b/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
@@ -5,8 +5,8 @@
     <SupportedOSPlatformVersion>26</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ApplicationId>one.nerva.android</ApplicationId>
-    <ApplicationVersion>1102</ApplicationVersion>
-    <ApplicationDisplayVersion>1.1.2</ApplicationDisplayVersion>
+    <ApplicationVersion>1104</ApplicationVersion>
+    <ApplicationDisplayVersion>1.1.4</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidEnableProfiledAot>False</AndroidEnableProfiledAot>
     <RuntimeIdentifiers>android-arm64</RuntimeIdentifiers>

--- a/NervaOneWalletMiner/Helpers/GlobalData.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalData.cs
@@ -17,7 +17,7 @@ namespace NervaOneWalletMiner.Helpers
     {
         public const string AppNameMain = "NervaOne";
         public const string AppAssemblyName = "NervaOneWalletMiner";
-        public const string Version = "1.1.2";
+        public const string Version = "1.1.4";
 
         public const string CliToolsDirName = "cli";
         public const string WalletDirName = "wallets";

--- a/NervaOneWalletMiner/Helpers/GlobalData.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalData.cs
@@ -17,7 +17,7 @@ namespace NervaOneWalletMiner.Helpers
     {
         public const string AppNameMain = "NervaOne";
         public const string AppAssemblyName = "NervaOneWalletMiner";
-        public const string Version = "1.1.4";
+        public const string Version = "1.1.5";
 
         public const string CliToolsDirName = "cli";
         public const string WalletDirName = "wallets";

--- a/NervaOneWalletMiner/Helpers/GlobalMethods.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalMethods.cs
@@ -18,6 +18,7 @@ using NervaOneWalletMiner.Rpc.Wallet.Responses;
 using NervaOneWalletMiner.ViewModels;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Formats.Tar;
 using System.IO;
 using System.IO.Compression;
@@ -763,6 +764,10 @@ namespace NervaOneWalletMiner.Helpers
                     {
                         Logger.LogDebug("GLM.SUCT", "Deleting compressed file: " + destFileWithPath);
                         File.Delete(destFileWithPath);
+                        if (IsOsx())
+                        {
+                            RemoveMacOsQuarantine(cliToolsPath);
+                        }
                         UIManager.UpdateDaemonStatus("Client tools download complete");
                     }
                     else
@@ -998,6 +1003,26 @@ namespace NervaOneWalletMiner.Helpers
             catch (Exception ex)
             {
                 Logger.LogException("GLM.EXTR", ex); ;
+            }
+        }
+
+        private static void RemoveMacOsQuarantine(string path)
+        {
+            try
+            {
+                Logger.LogDebug("GLM.RMQT", "Attempting to remove macOS quarantine from: " + path);
+                using Process? proc = Process.Start(new ProcessStartInfo("xattr", "-dr com.apple.quarantine \"" + path + "\"")
+                {
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false
+                });
+                proc?.WaitForExit(5000);
+                Logger.LogDebug("GLM.RMQT", "Removed macOS quarantine from: " + path);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("GLM.RMQT", ex);
             }
         }
 

--- a/NervaOneWalletMiner/Helpers/GlobalMethods.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalMethods.cs
@@ -383,12 +383,15 @@ namespace NervaOneWalletMiner.Helpers
 
                 switch (newCoin)
                 {
-                    case Coin.XMR:                        
+                    case Coin.XMR:
                         GlobalData.CoinDirName = Coin.XMR;
                         GlobalData.AppSettings.ActiveCoin = Coin.XMR;
 
                         GlobalData.DaemonService = new DaemonServiceXMR();
                         GlobalData.WalletService = new WalletServiceXMR();
+
+                        GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].Rpc.UserName = GenerateRandomString(24);
+                        GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].Rpc.Password = GenerateRandomString(24);
                         break;
 
                     case Coin.WOW:
@@ -397,6 +400,9 @@ namespace NervaOneWalletMiner.Helpers
 
                         GlobalData.DaemonService = new DaemonServiceWOW();
                         GlobalData.WalletService = new WalletServiceWOW();
+
+                        GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].Rpc.UserName = GenerateRandomString(24);
+                        GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].Rpc.Password = GenerateRandomString(24);
                         break;
 
                     case Coin.DASH:                        
@@ -466,6 +472,9 @@ namespace NervaOneWalletMiner.Helpers
 
                         GlobalData.DaemonService = new DaemonServiceXNV();
                         GlobalData.WalletService = new WalletServiceXNV();
+
+                        GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].Rpc.UserName = GenerateRandomString(24);
+                        GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].Rpc.Password = GenerateRandomString(24);
                         break;
                 }
 

--- a/NervaOneWalletMiner/Helpers/ProcessManager.cs
+++ b/NervaOneWalletMiner/Helpers/ProcessManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace NervaOneWalletMiner.Helpers
 {
@@ -227,7 +228,10 @@ namespace NervaOneWalletMiner.Helpers
         {
             try
             {
-                Logger.LogDebug("PRM.STEP", "Starting process: " + ExeNameToProcessName(exePath) + " with args: " + args);
+                string safeArgs = Regex.Replace(args, @"--rpc-login\s+\S+", "--rpc-login ***");
+                safeArgs = Regex.Replace(safeArgs, @"-rpcuser=\S+", "-rpcuser=***");
+                safeArgs = Regex.Replace(safeArgs, @"-rpcpassword=\S+", "-rpcpassword=***");
+                Logger.LogDebug("PRM.STEP", "Starting process: " + ExeNameToProcessName(exePath) + " with args: " + safeArgs);
 
                 string fileName = exePath;
                 string arguments = args;

--- a/NervaOneWalletMiner/Objects/Settings/CoinSpecific/CoinSettingsWOW.cs
+++ b/NervaOneWalletMiner/Objects/Settings/CoinSpecific/CoinSettingsWOW.cs
@@ -132,8 +132,9 @@ namespace NervaOneWalletMiner.Objects.Settings.CoinSpecific
                 appCommand = "--daemon-address " + daemonSettings.Rpc.Host + ":" + daemonSettings.Rpc.Port;
             }
 
+            appCommand += " --rpc-bind-ip 127.0.0.1";
             appCommand += " --rpc-bind-port " + walletSettings.Rpc.Port;
-            appCommand += " --disable-rpc-login";
+            appCommand += " --rpc-login " + walletSettings.Rpc.UserName + ":" + walletSettings.Rpc.Password;
             appCommand += " --wallet-dir \"" + GlobalData.WalletDir + "\"";
             appCommand += " --log-level " + walletSettings.LogLevel;
             appCommand += " --log-file \"" + GlobalMethods.CycleLogFile(GlobalMethods.GetRpcWalletProcess()) + "\"";

--- a/NervaOneWalletMiner/Objects/Settings/CoinSpecific/CoinSettingsXMR.cs
+++ b/NervaOneWalletMiner/Objects/Settings/CoinSpecific/CoinSettingsXMR.cs
@@ -132,8 +132,9 @@ namespace NervaOneWalletMiner.Objects.Settings.CoinSpecific
                 appCommand = "--daemon-address " + daemonSettings.Rpc.Host + ":" + daemonSettings.Rpc.Port;
             }
 
+            appCommand += " --rpc-bind-ip 127.0.0.1";
             appCommand += " --rpc-bind-port " + walletSettings.Rpc.Port;
-            appCommand += " --disable-rpc-login";
+            appCommand += " --rpc-login " + walletSettings.Rpc.UserName + ":" + walletSettings.Rpc.Password;
             appCommand += " --wallet-dir \"" + GlobalData.WalletDir + "\"";
             appCommand += " --log-level " + walletSettings.LogLevel;
             appCommand += " --log-file \"" + GlobalMethods.CycleLogFile(GlobalMethods.GetRpcWalletProcess()) + "\"";

--- a/NervaOneWalletMiner/Objects/Settings/CoinSpecific/CoinSettingsXNV.cs
+++ b/NervaOneWalletMiner/Objects/Settings/CoinSpecific/CoinSettingsXNV.cs
@@ -137,8 +137,9 @@ namespace NervaOneWalletMiner.Objects.Settings.CoinSpecific
                 appCommand = "--daemon-address " + daemonSettings.Rpc.Host + ":" + daemonSettings.Rpc.Port;
             }
 
+            appCommand += " --rpc-bind-ip 127.0.0.1";
             appCommand += " --rpc-bind-port " + walletSettings.Rpc.Port;
-            appCommand += " --disable-rpc-login";
+            appCommand += " --rpc-login " + walletSettings.Rpc.UserName + ":" + walletSettings.Rpc.Password;
             appCommand += " --wallet-dir \"" + GlobalData.WalletDir + "\"";
             appCommand += " --log-level " + walletSettings.LogLevel;
             appCommand += " --log-file \"" + GlobalMethods.CycleLogFile(GlobalMethods.GetRpcWalletProcess()) + "\"";

--- a/NervaOneWalletMiner/Objects/Settings/SettingsWallet.cs
+++ b/NervaOneWalletMiner/Objects/Settings/SettingsWallet.cs
@@ -4,7 +4,7 @@ namespace NervaOneWalletMiner.Objects.Settings
 {
     public class SettingsWallet
     {
-        public RpcBase Rpc { get; set; } = new RpcBase();
+        public TransientRpcBase Rpc { get; set; } = new TransientRpcBase();
 
         public string PublicNodeAddress { get; set; }  = string.Empty;
 

--- a/NervaOneWalletMiner/Rpc/Common/HttpHelper.cs
+++ b/NervaOneWalletMiner/Rpc/Common/HttpHelper.cs
@@ -1,8 +1,12 @@
-﻿using NervaOneWalletMiner.Helpers;
+using NervaOneWalletMiner.Helpers;
 using System;
+using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,13 +14,22 @@ namespace NervaOneWalletMiner.Rpc.Common
 {
     public static class HttpHelper
     {
+        private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(50);
+
         private static readonly HttpClient _client = new HttpClient()
         {
             Timeout = Timeout.InfiniteTimeSpan
         };
 
-        private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(50);
+        // Cached Digest auth params - reused preemptively to avoid double round-trip
+        private static string? _cachedRealm;
+        private static string? _cachedNonce;
+        private static string? _cachedQop;
+        private static string? _cachedOpaque;
+        private static int _cachedNc;
+        private static string _cachedKey = string.Empty;
 
+        #region No Auth
         public static async Task<HttpResponseMessage> GetPostFromService(string serviceUrl, string postContent)
         {
             return await GetPostFromService(serviceUrl, postContent, _defaultTimeout);
@@ -47,7 +60,9 @@ namespace NervaOneWalletMiner.Rpc.Common
 
             return response;
         }
+        #endregion // No Auth
 
+        #region Basic Auth
         public static async Task<HttpResponseMessage> GetPostFromService(string serviceUrl, string postContent, string userName, string password)
         {
             return await GetPostFromService(serviceUrl, postContent, userName, password, _defaultTimeout);
@@ -83,7 +98,149 @@ namespace NervaOneWalletMiner.Rpc.Common
 
             return response;
         }
+        #endregion // Basic Auth
 
+        #region Digest Auth
+        public static async Task<HttpResponseMessage> GetPostFromServiceDigestAuth(RpcBase rpc, string path, string postContent)
+        {
+            return await GetPostFromServiceDigestAuth(rpc, path, postContent, _defaultTimeout);
+        }
+
+        public static async Task<HttpResponseMessage> GetPostFromServiceDigestAuth(RpcBase rpc, string path, string postContent, TimeSpan timeout)
+        {
+            HttpResponseMessage response = new HttpResponseMessage();
+
+            try
+            {
+                using CancellationTokenSource cts = new CancellationTokenSource(timeout);
+                string serviceUrl = GetServiceUrl(rpc, path);
+
+                // Send preemptively with cached auth if available, otherwise unauthenticated to get the challenge
+                string? preemptiveAuth = TryBuildPreemptiveAuthHeader(HttpMethod.Post.Method, serviceUrl, rpc.UserName, rpc.Password);
+
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, serviceUrl);
+                request.Content = new StringContent(postContent);
+                request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+                if (preemptiveAuth != null)
+                {
+                    request.Headers.TryAddWithoutValidation("Authorization", preemptiveAuth);
+                }
+
+                response = await _client.SendAsync(request, cts.Token);
+
+                if (response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    // Cache miss, stale nonce, or first request - do full challenge-response
+                    string? authHeader = BuildDigestAuthHeader(response, HttpMethod.Post.Method, serviceUrl, rpc.UserName, rpc.Password);
+                    if (authHeader != null)
+                    {
+                        HttpRequestMessage retryRequest = new HttpRequestMessage(HttpMethod.Post, serviceUrl);
+                        retryRequest.Content = new StringContent(postContent);
+                        retryRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+                        retryRequest.Headers.TryAddWithoutValidation("Authorization", authHeader);
+                        response = await _client.SendAsync(retryRequest, cts.Token);
+                    }
+                    else
+                    {
+                        // No WWW-Authenticate header - clear cache so the next call does a fresh challenge-response
+                        _cachedRealm = null;
+                        _cachedNonce = null;
+                        _cachedKey = string.Empty;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("HTTP.GPDA", "Exception message: " + ex.Message);
+            }
+
+            return response;
+        }
+
+        private static string? TryBuildPreemptiveAuthHeader(string method, string serviceUrl, string userName, string password)
+        {
+            string key = userName + ":" + password;
+            if (_cachedRealm == null || _cachedNonce == null || _cachedKey != key)
+            {
+                return null;
+            }
+
+            int nc = Interlocked.Increment(ref _cachedNc);
+            string ncStr = nc.ToString("x8");
+            string cnonce = Guid.NewGuid().ToString("N")[..8];
+            string uri = new Uri(serviceUrl).PathAndQuery;
+
+            string credentialsHash = ComputeMD5($"{userName}:{_cachedRealm}:{password}");
+            string requestHash = ComputeMD5($"{method}:{uri}");
+            string digestResponse  = string.IsNullOrEmpty(_cachedQop)
+                ? ComputeMD5($"{credentialsHash}:{_cachedNonce}:{requestHash}")
+                : ComputeMD5($"{credentialsHash}:{_cachedNonce}:{ncStr}:{cnonce}:{_cachedQop}:{requestHash}");
+
+            string header = $"Digest username=\"{userName}\", realm=\"{_cachedRealm}\", nonce=\"{_cachedNonce}\", uri=\"{uri}\", response=\"{digestResponse}\"";
+            if (!string.IsNullOrEmpty(_cachedQop))    { header += $", qop={_cachedQop}, nc={ncStr}, cnonce=\"{cnonce}\""; }
+            if (!string.IsNullOrEmpty(_cachedOpaque)) { header += $", opaque=\"{_cachedOpaque}\""; }
+
+            return header;
+        }
+
+        private static string? BuildDigestAuthHeader(HttpResponseMessage challengeResponse, string method, string serviceUrl, string userName, string password)
+        {
+            try
+            {
+                string wwwAuth = challengeResponse.Headers.WwwAuthenticate.FirstOrDefault()?.ToString() ?? string.Empty;
+                if (string.IsNullOrEmpty(wwwAuth)) { return null; }
+
+                string realm = GetDigestParam(wwwAuth, "realm");
+                string nonce = GetDigestParam(wwwAuth, "nonce");
+                string qop = GetDigestParam(wwwAuth, "qop");
+                string opaque = GetDigestParam(wwwAuth, "opaque");
+                string uri = new Uri(serviceUrl).PathAndQuery;
+                string nc = "00000001";
+                string cnonce = Guid.NewGuid().ToString("N")[..8];
+
+                // RFC 2617 Digest auth: credentialsHash = MD5(user:realm:pass), requestHash = MD5(method:uri)
+                string credentialsHash = ComputeMD5($"{userName}:{realm}:{password}");
+                string requestHash = ComputeMD5($"{method}:{uri}");
+                string digestResponse  = string.IsNullOrEmpty(qop)
+                    ? ComputeMD5($"{credentialsHash}:{nonce}:{requestHash}")
+                    : ComputeMD5($"{credentialsHash}:{nonce}:{nc}:{cnonce}:{qop}:{requestHash}");
+
+                string header = $"Digest username=\"{userName}\", realm=\"{realm}\", nonce=\"{nonce}\", uri=\"{uri}\", response=\"{digestResponse}\"";
+                if (!string.IsNullOrEmpty(qop))    { header += $", qop={qop}, nc={nc}, cnonce=\"{cnonce}\""; }
+                if (!string.IsNullOrEmpty(opaque)) { header += $", opaque=\"{opaque}\""; }
+
+                // Update cache so subsequent requests can authenticate preemptively
+                _cachedRealm = realm;
+                _cachedNonce = nonce;
+                _cachedQop = qop;
+                _cachedOpaque = opaque;
+                _cachedNc = 1;
+                _cachedKey = userName + ":" + password;
+
+                return header;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("HTTP.BDAH", "Exception: " + ex.Message);
+                return null;
+            }
+        }
+
+        private static string ComputeMD5(string input)
+        {
+            using MD5 md5 = MD5.Create();
+            byte[] bytes = md5.ComputeHash(Encoding.ASCII.GetBytes(input));
+            return BitConverter.ToString(bytes).Replace("-", string.Empty).ToLowerInvariant();
+        }
+
+        private static string GetDigestParam(string header, string name)
+        {
+            Match match = Regex.Match(header, name + @"=""?([^"",\s]+)""?");
+            return match.Success ? match.Groups[1].Value : string.Empty;
+        }
+        #endregion // Digest Auth
+
+        #region Helpers
         public static async Task<ServiceError> GetHttpError(string source, HttpResponseMessage httpResponse)
         {
             ServiceError httpError = new();
@@ -127,5 +284,6 @@ namespace NervaOneWalletMiner.Rpc.Common
 
             return serviceUrl;
         }
+        #endregion // Helpers
     }
 }

--- a/NervaOneWalletMiner/Rpc/Common/RpcBase.cs
+++ b/NervaOneWalletMiner/Rpc/Common/RpcBase.cs
@@ -10,7 +10,7 @@ namespace NervaOneWalletMiner.Rpc.Common
         public int Port { get; set; } = -1;
 
         // Required for some coins only
-        public string UserName { get; set; } = string.Empty;
-        public string Password { get; set; } = string.Empty;
+        public virtual string UserName { get; set; } = string.Empty;
+        public virtual string Password { get; set; } = string.Empty;
     }
 }

--- a/NervaOneWalletMiner/Rpc/Common/TransientRpcBase.cs
+++ b/NervaOneWalletMiner/Rpc/Common/TransientRpcBase.cs
@@ -1,0 +1,14 @@
+using Newtonsoft.Json;
+
+namespace NervaOneWalletMiner.Rpc.Common
+{
+    // Credentials are excluded from serialization - regenerated fresh each session
+    public class TransientRpcBase : RpcBase
+    {
+        [JsonIgnore]
+        public override string UserName { get; set; } = string.Empty;
+
+        [JsonIgnore]
+        public override string Password { get; set; } = string.Empty;
+    }
+}

--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceBaseXMR.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceBaseXMR.cs
@@ -103,7 +103,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -158,7 +158,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -219,7 +219,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -280,7 +280,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -339,7 +339,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -386,7 +386,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -456,7 +456,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -554,7 +554,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -670,7 +670,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -748,7 +748,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     ["params"] = paramsJson
                 };
 
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -802,7 +802,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     ["params"] = new JObject { ["hex"] = txMetadata }
                 };
 
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -910,7 +910,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -984,7 +984,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -1037,7 +1037,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -1096,7 +1096,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -1167,7 +1167,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -1289,7 +1289,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -1419,7 +1419,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -1506,7 +1506,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -1591,7 +1591,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 }
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -1632,7 +1632,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                                     ["params"] = new JObject() { ["key_type"] = "spend_key" }
                                 };
 
-                                httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                                httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                                 if (httpResponse.IsSuccessStatusCode)
                                 {
                                     jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -1721,7 +1721,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -1894,7 +1894,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 Logger.LogDebug(CoinPrefix + ".SWBL", "Calling sweep_all with below_amount: " + requestObj.Amount);
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString(), _sweepTimeout);
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString(), _sweepTimeout);
                 Logger.LogDebug(CoinPrefix + ".SWBL", "sweep_all returned.");
                 if (httpResponse.IsSuccessStatusCode)
                 {

--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceXNV.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceXNV.cs
@@ -53,7 +53,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -146,7 +146,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());
@@ -233,7 +233,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                 }
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromServiceDigestAuth(rpc, "json_rpc", requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());

--- a/NervaOneWalletMiner/ViewModels/DaemonSetupViewModel.cs
+++ b/NervaOneWalletMiner/ViewModels/DaemonSetupViewModel.cs
@@ -323,6 +323,15 @@ namespace NervaOneWalletMiner.ViewModels
                 if (GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].IsWalletOnly)
                 {
                     Logger.LogDebug("DSM.RWCM", "Running as Wallet Only");
+                    if (GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].IsDaemonWalletSeparateApp
+                        && GlobalMethods.DirectoryContainsCliTools(GlobalData.CliToolsDir))
+                    {
+                        ProcessManager.StartExternalProcess(
+                            GlobalMethods.GetRpcWalletProcess(),
+                            GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].GenerateWalletOptions(
+                                GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin],
+                                GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin]));
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
## Changes

**Wallet-rpc authentication (XNV, XMR, WOW)**
- XNV, XMR, and WOW wallet-rpc now starts with `--rpc-bind-ip 127.0.0.1` and `--rpc-login`
- Implemented manual RFC 2617 Digest authentication in `HttpHelper` - fully platform-agnostic, including Android where the default HTTP handler does not support Digest auth natively
- Added preemptive auth cache to reuse nonce/realm across requests, reducing round-trips and handling concurrent requests correctly
- Introduced `TransientRpcBase` - wallet-rpc credentials are excluded from config serialization and regenerated fresh each session
- RPC credentials are masked in debug log output

**Wallet-only mode fix**
- Wallet RPC now restarts immediately when switching to wallet-only mode instead of waiting for the 60-second health check, preventing "could not open wallet" errors after changing node type