### PR TITLE
Require password on BTC-based coins on wallet creation and restore

### DIFF
--- a/NervaOneWalletMiner/Views/CreateWalletView.axaml.cs
+++ b/NervaOneWalletMiner/Views/CreateWalletView.axaml.cs
@@ -32,8 +32,8 @@ namespace NervaOneWalletMiner.Views
                 if (_isBtcStyle)
                 {
                     pnlLanguage.IsVisible = false;
-                    lbPassword.Content = "Password (Optional)";
-                    tbxPassword.Watermark = "Optional - encrypt the wallet with a password";
+                    lbPassword.Content = "Password (Required)";
+                    tbxPassword.Watermark = "Required - encrypt the wallet with a password";
                     btnOk.IsVisible = !_isSeedSupported;
                     btnNext.IsVisible = _isSeedSupported;
                 }
@@ -74,6 +74,12 @@ namespace NervaOneWalletMiner.Views
                 else if (walletName.Contains('/') || walletName.Contains('\\') || walletName.Contains(".."))
                 {
                     await DialogService.ShowAsync(new MessageBoxView("Create Wallet", "Wallet Name cannot contain path characters.", true));
+                    return;
+                }
+
+                if (string.IsNullOrEmpty(tbxPassword.Text))
+                {
+                    await DialogService.ShowAsync(new MessageBoxView("Create Wallet", "Password is required.", true));
                     return;
                 }
 
@@ -267,7 +273,13 @@ namespace NervaOneWalletMiner.Views
                 return;
             }
 
-            char[] walletPassword = string.IsNullOrEmpty(tbxPassword.Text) ? [] : tbxPassword.Text.ToCharArray();
+            if (string.IsNullOrEmpty(tbxPassword.Text))
+            {
+                await DialogService.ShowAsync(new MessageBoxView("Create Wallet", "Password is required.", true));
+                return;
+            }
+
+            char[] walletPassword = tbxPassword.Text.ToCharArray();
 
             tbxPassword.Text = string.Empty;
             btnOk.Content = "Creating...";

--- a/NervaOneWalletMiner/Views/RestoreFromDumpFileView.axaml
+++ b/NervaOneWalletMiner/Views/RestoreFromDumpFileView.axaml
@@ -42,7 +42,7 @@
 						 Watermark="Required - path to wallet dump file"/>
 			</DockPanel>
 
-			<Label Content="Password (Optional)" Margin="0,15,0,0"/>
+			<Label Content="Password (Required)" Margin="0,15,0,0"/>
 			<DockPanel>
 				<Button Name="btnShowHidePassword"
 						DockPanel.Dock="Right"
@@ -51,7 +51,7 @@
 						IsTabStop="False"
 						Click="ShowHidePassword_Clicked"/>
 				<TextBox Name="tbxPassword"
-						 Watermark="Optional - leave blank for no password"
+						 Watermark="Required - encrypt the wallet with a password"
 						 PasswordChar="*"
 						 RevealPassword="False"/>
 			</DockPanel>

--- a/NervaOneWalletMiner/Views/RestoreFromDumpFileView.axaml.cs
+++ b/NervaOneWalletMiner/Views/RestoreFromDumpFileView.axaml.cs
@@ -79,6 +79,12 @@ namespace NervaOneWalletMiner.Views
                     return;
                 }
 
+                if (string.IsNullOrEmpty(tbxPassword.Text))
+                {
+                    await DialogService.ShowAsync(new MessageBoxView("Restore From Dump File", "Password is required.", true));
+                    return;
+                }
+
                 MessageBoxView confirmWindow = new("Restore Wallet", "This will create a new wallet '" + walletName + "' and import all keys from the dump file. A blockchain scan will be performed which may take some time. Continue?", false, true);
                 DialogResult? confirmRes = await DialogService.ShowAsync<DialogResult>(confirmWindow);
                 if (confirmRes == null || !confirmRes.IsOk)
@@ -86,7 +92,7 @@ namespace NervaOneWalletMiner.Views
                     return;
                 }
 
-                char[] walletPassword = string.IsNullOrEmpty(tbxPassword.Text) ? [] : tbxPassword.Text.ToCharArray();
+                char[] walletPassword = tbxPassword.Text.ToCharArray();
                 tbxPassword.Text = string.Empty;
 
                 btnOk.Content = "Restoring...";

--- a/NervaOneWalletMiner/Views/RestoreFromSeedView.axaml.cs
+++ b/NervaOneWalletMiner/Views/RestoreFromSeedView.axaml.cs
@@ -29,8 +29,8 @@ namespace NervaOneWalletMiner.Views
                     pnlLanguage.IsVisible = false;
                     lbSeedOffset.Content = "BIP39 Passphrase (optional 25th word)";
                     tbxSeedOffset.Watermark = "Optional - extra passphrase added to your seed phrase";
-                    lbPassword.Content = "Wallet Password (Optional)";
-                    tbxPassword.Watermark = "Optional - encrypt the wallet with a password";
+                    lbPassword.Content = "Wallet Password (Required)";
+                    tbxPassword.Watermark = "Required - encrypt the wallet with a password";
                 }
                 else
                 {
@@ -67,7 +67,7 @@ namespace NervaOneWalletMiner.Views
                     return;
                 }
 
-                if (!_isBtcStyle && string.IsNullOrEmpty(tbxPassword.Text))
+                if (string.IsNullOrEmpty(tbxPassword.Text))
                 {
                     await DialogService.ShowAsync(new MessageBoxView("Restore From Seed", "Seed Phrase, Wallet Name and Password are all required.", true));
                     return;
@@ -92,7 +92,7 @@ namespace NervaOneWalletMiner.Views
 
                 char[] seed = tbxSeedPhrase.Text.ToCharArray();
                 string seedOffset = tbxSeedOffset.Text ?? string.Empty;
-                char[] walletPassword = string.IsNullOrEmpty(tbxPassword.Text) ? [] : tbxPassword.Text.ToCharArray();
+                char[] walletPassword = tbxPassword.Text.ToCharArray();
                 string walletLanguage = _isBtcStyle
                     ? Language.English
                     : (cbxLanguage.SelectedValue == null ? Language.English : cbxLanguage.SelectedValue.ToString()!);


### PR DESCRIPTION
Force a non-empty password when creating or restoring BTC/LTC/DASH wallets so wallet.dat is always encrypted at rest. Opening existing unencrypted wallets still works.