### PR TITLE
Fix precision loss in atomic-unit to amount conversion

### DIFF
--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceBaseXMR.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/XmrBased/WalletServiceBaseXMR.cs
@@ -27,7 +27,7 @@ namespace NervaOneWalletMiner.Rpc.Wallet
         private static readonly TimeSpan _sweepTimeout = TimeSpan.FromMinutes(60);
 
         protected decimal AmountFromAtomicUnits(ulong value, int decimalPlaces) =>
-            Math.Round(Convert.ToDecimal(value / (double)CoinAtomicUnits), decimalPlaces);
+            Math.Round(value / CoinAtomicUnits, decimalPlaces);
 
         protected ulong AtomicUnitsFromAmount(decimal amount) =>
             (ulong)(amount * CoinAtomicUnits);


### PR DESCRIPTION
AmountFromAtomicUnits divided through double, losing precision in the trailing digits for amounts shown at full precision (Transfer Funds balance, send confirmation, CSV export).

Divide in decimal directly so the displayed value matches the true atomic-unit amount.