### PR TITLE
Update Nerva and Dash CLI links and bump version

### DIFF
--- a/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
+++ b/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
@@ -5,8 +5,8 @@
     <SupportedOSPlatformVersion>26</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ApplicationId>one.nerva.android</ApplicationId>
-    <ApplicationVersion>1200</ApplicationVersion>
-    <ApplicationDisplayVersion>1.2.0</ApplicationDisplayVersion>
+    <ApplicationVersion>1201</ApplicationVersion>
+    <ApplicationDisplayVersion>1.2.1</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidEnableProfiledAot>False</AndroidEnableProfiledAot>
     <RuntimeIdentifiers>android-arm64</RuntimeIdentifiers>

--- a/NervaOneWalletMiner/Helpers/GlobalData.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalData.cs
@@ -17,7 +17,7 @@ namespace NervaOneWalletMiner.Helpers
     {
         public const string AppNameMain = "NervaOne";
         public const string AppAssemblyName = "NervaOneWalletMiner";
-        public const string Version = "1.2.0";
+        public const string Version = "1.2.1";
 
         public const string CliToolsDirName = "cli";
         public const string WalletDirName = "wallets";

--- a/NervaOneWalletMiner/Objects/Settings/CoinSpecific/CoinSettingsDASH.cs
+++ b/NervaOneWalletMiner/Objects/Settings/CoinSpecific/CoinSettingsDASH.cs
@@ -19,13 +19,13 @@ namespace NervaOneWalletMiner.Objects.Settings.CoinSpecific
         public string BlockchainDbSubfolder { get; set; } = string.Empty;
 
         // https://github.com/dashpay/dash/releases
-        public string CliUrlWindows64 { get; set; } = "https://github.com/dashpay/dash/releases/download/v23.1.3/dashcore-23.1.3-win64.zip";
-        public string CliUrlWindows32 { get; set; } = "https://github.com/dashpay/dash/releases/download/v23.1.3/dashcore-23.1.3-win64.zip";
-        public string CliUrlLinux64 { get; set; } = "https://github.com/dashpay/dash/releases/download/v23.1.3/dashcore-23.1.3-x86_64-linux-gnu.tar.gz";
-        public string CliUrlLinux32 { get; set; } = "https://github.com/dashpay/dash/releases/download/v23.1.3/dashcore-23.1.3-x86_64-linux-gnu.tar.gz";
-        public string CliUrlLinuxArm { get; set; } = "https://github.com/dashpay/dash/releases/download/v23.1.3/dashcore-23.1.3-aarch64-linux-gnu.tar.gz";
-        public string CliUrlMacIntel { get; set; } = "https://github.com/dashpay/dash/releases/download/v23.1.3/dashcore-23.1.3-x86_64-apple-darwin.tar.gz";
-        public string CliUrlMacArm { get; set; } = "https://github.com/dashpay/dash/releases/download/v23.1.3/dashcore-23.1.3-arm64-apple-darwin.tar.gz";
+        public string CliUrlWindows64 { get; set; } = "https://github.com/dashpay/dash/releases/download/v23.1.4/dashcore-23.1.4-win64.zip";
+        public string CliUrlWindows32 { get; set; } = "https://github.com/dashpay/dash/releases/download/v23.1.4/dashcore-23.1.4-win64.zip";
+        public string CliUrlLinux64 { get; set; } = "https://github.com/dashpay/dash/releases/download/v23.1.4/dashcore-23.1.4-x86_64-linux-gnu.tar.gz";
+        public string CliUrlLinux32 { get; set; } = "https://github.com/dashpay/dash/releases/download/v23.1.4/dashcore-23.1.4-x86_64-linux-gnu.tar.gz";
+        public string CliUrlLinuxArm { get; set; } = "https://github.com/dashpay/dash/releases/download/v23.1.4/dashcore-23.1.4-aarch64-linux-gnu.tar.gz";
+        public string CliUrlMacIntel { get; set; } = "https://github.com/dashpay/dash/releases/download/v23.1.4/dashcore-23.1.4-x86_64-apple-darwin.tar.gz";
+        public string CliUrlMacArm { get; set; } = "https://github.com/dashpay/dash/releases/download/v23.1.4/dashcore-23.1.4-arm64-apple-darwin.tar.gz";
         public string CliUrlAndroid { get; set; } = string.Empty;
 
         public string RemotePublicNodeUrlDefault { get; set; } = string.Empty;

--- a/NervaOneWalletMiner/Objects/Settings/CoinSpecific/CoinSettingsXNV.cs
+++ b/NervaOneWalletMiner/Objects/Settings/CoinSpecific/CoinSettingsXNV.cs
@@ -18,14 +18,14 @@ namespace NervaOneWalletMiner.Objects.Settings.CoinSpecific
         public string BlockchainDbSubfolder { get; set; } = "lmdb";
 
         // https://github.com/nerva-project/nerva/releases
-        public string CliUrlWindows64 { get; set; } = "https://github.com/nerva-project/nerva/releases/download/v0.2.2.0/nerva-windows-x64-v0.2.2.0.zip";
-        public string CliUrlWindows32 { get; set; } = "https://github.com/nerva-project/nerva/releases/download/v0.2.2.0/nerva-windows-x32-v0.2.2.0.zip";
-        public string CliUrlLinux64 { get; set; } = "https://github.com/nerva-project/nerva/releases/download/v0.2.2.0/nerva-linux-x86_64-v0.2.2.0.tar.bz2";
-        public string CliUrlLinux32 { get; set; } = "https://github.com/nerva-project/nerva/releases/download/v0.2.2.0/nerva-linux-i686-v0.2.2.0.tar.bz2";
-        public string CliUrlLinuxArm { get; set; } = "https://github.com/nerva-project/nerva/releases/download/v0.2.2.0/nerva-linux-armv8-v0.2.2.0.tar.bz2";
-        public string CliUrlMacIntel { get; set; } = "https://github.com/nerva-project/nerva/releases/download/v0.2.2.0/nerva-macos-x64-v0.2.2.0.tar.bz2";
-        public string CliUrlMacArm { get; set; } = "https://github.com/nerva-project/nerva/releases/download/v0.2.2.0/nerva-macos-armv8-v0.2.2.0.tar.bz2";
-        public string CliUrlAndroid { get; set; } = "https://github.com/nerva-project/nerva/releases/download/v0.2.2.0/nerva-android-armv8-v0.2.2.0.tar.bz2";
+        public string CliUrlWindows64 { get; set; } = "https://github.com/nerva-project/nerva/releases/download/v0.2.3.0/nerva-windows-x64-v0.2.3.0.zip";
+        public string CliUrlWindows32 { get; set; } = "https://github.com/nerva-project/nerva/releases/download/v0.2.3.0/nerva-windows-x32-v0.2.3.0.zip";
+        public string CliUrlLinux64 { get; set; } = "https://github.com/nerva-project/nerva/releases/download/v0.2.3.0/nerva-linux-x86_64-v0.2.3.0.tar.bz2";
+        public string CliUrlLinux32 { get; set; } = "https://github.com/nerva-project/nerva/releases/download/v0.2.3.0/nerva-linux-i686-v0.2.3.0.tar.bz2";
+        public string CliUrlLinuxArm { get; set; } = "https://github.com/nerva-project/nerva/releases/download/v0.2.3.0/nerva-linux-armv8-v0.2.3.0.tar.bz2";
+        public string CliUrlMacIntel { get; set; } = "https://github.com/nerva-project/nerva/releases/download/v0.2.3.0/nerva-macos-x64-v0.2.3.0.tar.bz2";
+        public string CliUrlMacArm { get; set; } = "https://github.com/nerva-project/nerva/releases/download/v0.2.3.0/nerva-macos-armv8-v0.2.3.0.tar.bz2";
+        public string CliUrlAndroid { get; set; } = "https://github.com/nerva-project/nerva/releases/download/v0.2.3.0/nerva-android-armv8-v0.2.3.0.tar.bz2";
 
         public string RemotePublicNodeUrlDefault { get; set; } = "node.nerva.one:17566";
         public string LocalPublicNodeArgumentsDefault { get; set; } = "--rpc-bind-ip 0.0.0.0 --confirm-external-bind";


### PR DESCRIPTION
Bump version and default CLI downloads:
Nerva v0.2.2.0 -> v0.2.3.0
Dash v23.1.3 -> v23.1.4 (mandatory Dash DoS fix)