### PR TITLE
Add sync progress bars and responsive text to status bar

### DIFF
--- a/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
+++ b/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
@@ -5,8 +5,8 @@
     <SupportedOSPlatformVersion>26</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ApplicationId>one.nerva.android</ApplicationId>
-    <ApplicationVersion>1300</ApplicationVersion>
-    <ApplicationDisplayVersion>1.3.0</ApplicationDisplayVersion>
+    <ApplicationVersion>1301</ApplicationVersion>
+    <ApplicationDisplayVersion>1.3.1</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidEnableProfiledAot>False</AndroidEnableProfiledAot>
     <RuntimeIdentifiers>android-arm64</RuntimeIdentifiers>

--- a/NervaOneWalletMiner/Helpers/GlobalData.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalData.cs
@@ -17,7 +17,7 @@ namespace NervaOneWalletMiner.Helpers
     {
         public const string AppNameMain = "NervaOne";
         public const string AppAssemblyName = "NervaOneWalletMiner";
-        public const string Version = "1.3.0";
+        public const string Version = "1.3.1";
 
         public const string CliToolsDirName = "cli";
         public const string WalletDirName = "wallets";
@@ -76,6 +76,9 @@ namespace NervaOneWalletMiner.Helpers
         
         // This is used by UI to control if user needs to enter password before they do some sensitive wallet task. It stores password Hash
         public static string WalletPasswordHash = string.Empty;
+
+        // Daemon and wallet routinely trail the tip by a block while a new one propagates. Only count being further behind than this        
+        public const ulong SyncProgressMinBlocksBehind = 3;
 
         // Grid and other UI data
         public static StatsDaemon NetworkStats = new();

--- a/NervaOneWalletMiner/Helpers/GlobalMethods.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalMethods.cs
@@ -1337,6 +1337,22 @@ namespace NervaOneWalletMiner.Helpers
         public static string FormatAmountFull(decimal amount) =>
             amount.ToString("0.############");
 
+        // Sync progress as 0-100. Returns 0 when target height is not known. Max 100
+        public static double GetSyncProgress(ulong currentHeight, ulong targetHeight)
+        {
+            if (targetHeight == 0)
+            {
+                return 0;
+            }
+
+            double progress = currentHeight / (double)targetHeight * 100d;
+            return progress > 100d ? 100d : progress;
+        }
+
+        // Floor rather than round so a wallet at 99.6% does not display 100% before it is actually done
+        public static string GetSyncProgressText(double progress) =>
+            Math.Floor(progress).ToString("0") + "%";
+
         public static string GetShorterString(string? text, int shorterLength)
         {
             if (string.IsNullOrEmpty(text))

--- a/NervaOneWalletMiner/Helpers/UIManager.cs
+++ b/NervaOneWalletMiner/Helpers/UIManager.cs
@@ -258,15 +258,27 @@ namespace NervaOneWalletMiner.Helpers
             }
         }
 
+        // Messages that fit on a phone use the same text at both status bar widths
         public static void UpdateDaemonStatus(string message)
+        {
+            UpdateDaemonStatus(message, message);
+        }
+
+        public static void UpdateDaemonStatus(string message, string shortMessage)
         {
             if (GlobalData.ViewModelPages.ContainsKey(SplitViewPages.MainView))
             {
-                if (((MainViewModel)GlobalData.ViewModelPages[SplitViewPages.MainView]).DaemonStatus != message)
+                MainViewModel mainViewVm = (MainViewModel)GlobalData.ViewModelPages[SplitViewPages.MainView];
+
+                if (mainViewVm.DaemonStatus != message)
                 {
-                    ((MainViewModel)GlobalData.ViewModelPages[SplitViewPages.MainView]).DaemonStatus = message;
+                    mainViewVm.DaemonStatus = message;
                 }
-            }            
+                if (mainViewVm.DaemonStatusShort != shortMessage)
+                {
+                    mainViewVm.DaemonStatusShort = shortMessage;
+                }
+            }
         }
 
         public static void UpdateDaemonVersion(string version)
@@ -276,6 +288,40 @@ namespace NervaOneWalletMiner.Helpers
                 if (((MainViewModel)GlobalData.ViewModelPages[SplitViewPages.MainView]).DaemonVersion != version)
                 {
                     ((MainViewModel)GlobalData.ViewModelPages[SplitViewPages.MainView]).DaemonVersion = version;
+                }
+            }
+        }
+
+        public static void UpdateDaemonSyncProgress(double progress, bool isSyncing)
+        {
+            if (GlobalData.ViewModelPages.ContainsKey(SplitViewPages.MainView))
+            {
+                MainViewModel mainViewVm = (MainViewModel)GlobalData.ViewModelPages[SplitViewPages.MainView];
+
+                if (mainViewVm.DaemonSyncProgress != progress)
+                {
+                    mainViewVm.DaemonSyncProgress = progress;
+                }
+                if (mainViewVm.IsDaemonSyncing != isSyncing)
+                {
+                    mainViewVm.IsDaemonSyncing = isSyncing;
+                }
+            }
+        }
+
+        public static void UpdateWalletSyncProgress(double progress, bool isSyncing)
+        {
+            if (GlobalData.ViewModelPages.ContainsKey(SplitViewPages.MainView))
+            {
+                MainViewModel mainViewVm = (MainViewModel)GlobalData.ViewModelPages[SplitViewPages.MainView];
+
+                if (mainViewVm.WalletSyncProgress != progress)
+                {
+                    mainViewVm.WalletSyncProgress = progress;
+                }
+                if (mainViewVm.IsWalletSyncing != isSyncing)
+                {
+                    mainViewVm.IsWalletSyncing = isSyncing;
                 }
             }
         }
@@ -413,6 +459,14 @@ namespace NervaOneWalletMiner.Helpers
                     return;
                 }
 
+                // Daemon is still catching up to the network when it is behind the tip. Heights come from get_info
+                // so they are only known with a local daemon. Wallet only mode never fetches daemon data
+                ulong netHeight = GlobalData.NetworkStats.NetHeight;
+                ulong yourHeight = GlobalData.NetworkStats.YourHeight;
+                bool isDaemonSyncing = netHeight > 0 && yourHeight > 0 && yourHeight + GlobalData.SyncProgressMinBlocksBehind <= netHeight;
+                double daemonProgress = isDaemonSyncing ? GlobalMethods.GetSyncProgress(yourHeight, netHeight) : 0;
+                UpdateDaemonSyncProgress(daemonProgress, isDaemonSyncing);
+
                 if (GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].IsWalletOnly)
                 {
                     string remoteStatus = "Remote" + (string.IsNullOrEmpty(GlobalData.NetworkStats.StatusSync) ? "" : " | " + GlobalData.NetworkStats.StatusSync);
@@ -438,9 +492,27 @@ namespace NervaOneWalletMiner.Helpers
                     int dashIndex = rawVersion.IndexOf('-');
                     string version = dashIndex > 0 ? rawVersion[..dashIndex] : rawVersion;
                     string connections = "↑" + GlobalData.NetworkStats.ConnectionsOut + "  ↓" + GlobalData.NetworkStats.ConnectionsIn;
-                    string sync = " | " + (string.IsNullOrEmpty(GlobalData.NetworkStats.StatusSync) ? "Connecting to daemon..." : GlobalData.NetworkStats.StatusSync);
+                    string connectionsShort = "↑" + GlobalData.NetworkStats.ConnectionsOut + " ↓" + GlobalData.NetworkStats.ConnectionsIn;
                     string publicIndicator = GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].IsPublicNode ? " | Public" : string.Empty;
-                    UpdateDaemonStatus(version + " | " + connections + sync + publicIndicator);
+
+                    // While syncing the heights are rebuilt here instead of using StatusSync so the narrow width can drop them.
+                    // StatusSync still carries the transient messages like "Loading..." at both widths
+                    string sync;
+                    string syncShort;
+                    if (isDaemonSyncing)
+                    {
+                        string percent = GlobalMethods.GetSyncProgressText(daemonProgress);
+                        sync = "Sync (" + yourHeight + " of " + netHeight + ") " + percent;
+                        syncShort = "Sync " + percent;
+                    }
+                    else
+                    {
+                        sync = string.IsNullOrEmpty(GlobalData.NetworkStats.StatusSync) ? "Connecting to daemon..." : GlobalData.NetworkStats.StatusSync;
+                        syncShort = sync;
+                    }
+
+                    UpdateDaemonStatus(version + " | " + connections + " | " + sync + publicIndicator,
+                        version + " | " + connectionsShort + " | " + syncShort + publicIndicator);
                 }
             }
             catch (Exception ex)
@@ -489,7 +561,33 @@ namespace NervaOneWalletMiner.Helpers
                     string units = GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].DisplayUnits;
                     string totalLockedLabel = "Total " + units + ":";
                     string totalUnlockedLabel = (isBtcStyle ? "Pending " : "Unlocked ") + units + ":";
-                    string statusBarMessage = GlobalData.OpenedWalletName + " | " + GlobalMethods.FormatAmount(GlobalData.WalletStats.BalanceTotal) + " " + units + (GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].IsWalletHeightSupported ? " | H: " + GlobalData.WalletHeight : string.Empty);
+                    bool isWalletHeightSupported = GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].IsWalletHeightSupported;
+
+                    // Wallet is still scanning the chain when it is behind the tip. BTC based coins have no wallet
+                    // scan height and wallet only mode has no tip height, so neither shows scan progress
+                    ulong walletNetHeight = GlobalData.NetworkStats.NetHeight;
+                    bool isWalletSyncing = isWalletHeightSupported && walletNetHeight > 0 && GlobalData.WalletHeight > 0 && GlobalData.WalletHeight + GlobalData.SyncProgressMinBlocksBehind <= walletNetHeight;
+                    double walletProgress = isWalletSyncing ? GlobalMethods.GetSyncProgress(GlobalData.WalletHeight, walletNetHeight) : 0;
+
+                    // Name and balance always fit so they are the base for both widths. Height is spelled out when
+                    // there is room and abbreviated on a phone, where scanning drops it entirely for the percent
+                    string statusBarMessage = GlobalData.OpenedWalletName + " | " + GlobalMethods.FormatAmount(GlobalData.WalletStats.BalanceTotal) + " " + units;
+                    string statusBarMessageShort = statusBarMessage;
+
+                    if (isWalletHeightSupported)
+                    {
+                        if (isWalletSyncing)
+                        {
+                            string percent = GlobalMethods.GetSyncProgressText(walletProgress);
+                            statusBarMessage += " | Height: " + GlobalData.WalletHeight + " (" + percent + ")";
+                            statusBarMessageShort += " | " + percent;
+                        }
+                        else
+                        {
+                            statusBarMessage += " | Height: " + GlobalData.WalletHeight;
+                            statusBarMessageShort += " | H: " + GlobalData.WalletHeight;
+                        }
+                    }
 
                     Dispatcher.UIThread.Invoke(() =>
                     {
@@ -560,6 +658,12 @@ namespace NervaOneWalletMiner.Helpers
                         {
                             mainViewVm.WalletStatus = statusBarMessage;
                         }
+                        if (mainViewVm.WalletStatusShort != statusBarMessageShort)
+                        {
+                            mainViewVm.WalletStatusShort = statusBarMessageShort;
+                        }
+
+                        UpdateWalletSyncProgress(walletProgress, isWalletSyncing);
                     });
                 }
                 else
@@ -597,6 +701,12 @@ namespace NervaOneWalletMiner.Helpers
                         {
                             mainViewVm.WalletStatus = GlobalData.WalletClosedMessage;
                         }
+                        if (mainViewVm.WalletStatusShort != GlobalData.WalletClosedMessage)
+                        {
+                            mainViewVm.WalletStatusShort = GlobalData.WalletClosedMessage;
+                        }
+
+                        UpdateWalletSyncProgress(0, false);
                     });
                 }
             }

--- a/NervaOneWalletMiner/ViewModels/MainViewModel.cs
+++ b/NervaOneWalletMiner/ViewModels/MainViewModel.cs
@@ -64,6 +64,13 @@ public class MainViewModel : ViewModelBase
         set => this.RaiseAndSetIfChanged(ref _DaemonStatus, value);
     }
 
+    private string _DaemonStatusShort = "";
+    public string DaemonStatusShort
+    {
+        get => _DaemonStatusShort;
+        set => this.RaiseAndSetIfChanged(ref _DaemonStatusShort, value);
+    }
+
     // Status Bar
     private string _DaemonVersion = "";
     public string DaemonVersion
@@ -77,6 +84,41 @@ public class MainViewModel : ViewModelBase
     {
         get => _WalletStatus;
         set => this.RaiseAndSetIfChanged(ref _WalletStatus, value);
+    }
+
+    private string _WalletStatusShort = "";
+    public string WalletStatusShort
+    {
+        get => _WalletStatusShort;
+        set => this.RaiseAndSetIfChanged(ref _WalletStatusShort, value);
+    }
+
+    private double _DaemonSyncProgress = 0;
+    public double DaemonSyncProgress
+    {
+        get => _DaemonSyncProgress;
+        set => this.RaiseAndSetIfChanged(ref _DaemonSyncProgress, value);
+    }
+
+    private bool _IsDaemonSyncing = false;
+    public bool IsDaemonSyncing
+    {
+        get => _IsDaemonSyncing;
+        set => this.RaiseAndSetIfChanged(ref _IsDaemonSyncing, value);
+    }
+
+    private double _WalletSyncProgress = 0;
+    public double WalletSyncProgress
+    {
+        get => _WalletSyncProgress;
+        set => this.RaiseAndSetIfChanged(ref _WalletSyncProgress, value);
+    }
+
+    private bool _IsWalletSyncing = false;
+    public bool IsWalletSyncing
+    {
+        get => _IsWalletSyncing;
+        set => this.RaiseAndSetIfChanged(ref _IsWalletSyncing, value);
     }
 
     private Bitmap _CoinIcon = GlobalData.Logo;

--- a/NervaOneWalletMiner/Views/StatusBarView.axaml
+++ b/NervaOneWalletMiner/Views/StatusBarView.axaml
@@ -5,32 +5,75 @@
 			 xmlns:vm="clr-namespace:NervaOneWalletMiner.ViewModels"
              mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="50"
 			 x:DataType="vm:MainViewModel"
-             x:Class="NervaOneWalletMiner.Views.StatusBarView">
+             x:Class="NervaOneWalletMiner.Views.StatusBarView"
+             SizeChanged="StatusBarView_SizeChanged">
 
 	<Design.DataContext>
 		<vm:StatusBarViewModel/>
 	</Design.DataContext>
 	
-	<Grid ColumnDefinitions="32,*,140" Margin="10" Height="50">
+	<Grid ColumnDefinitions="32,*" Margin="10" Height="50">
 		<Grid.RowDefinitions>
 			<RowDefinition Height="25"/>
 			<RowDefinition Height="25"/>
 		</Grid.RowDefinitions>
-		
+
 		<Image Grid.RowSpan="2"
 			   Grid.Column="0"
 			   Source="{Binding CoinIcon}"/>
-		
-		<Label Grid.Row="0"
+
+		<!-- One label per width. StatusBarView_SizeChanged shows exactly one of them -->
+		<Label Name="lblDaemonStatus"
+			   Grid.Row="0"
 			   Grid.Column="1"
-			   Grid.ColumnSpan="2"
 			   Margin="10,0,0,0"
 			   Content="{Binding DaemonStatus}"/>
-		<Label Grid.Row="1"
+		<Label Name="lblDaemonStatusShort"
+			   Grid.Row="0"
 			   Grid.Column="1"
-			   Grid.ColumnSpan="2"
+			   Margin="10,0,0,0"
+			   IsVisible="False"
+			   Content="{Binding DaemonStatusShort}"/>
+		<!-- Sits on the bottom edge of the status row so it takes no extra height and no text width. The track is
+			 transparent so only the filled part shows - a full width track reads as a horizontal scrollbar -->
+		<ProgressBar Grid.Row="0"
+					 Grid.Column="1"
+					 Margin="10,0,0,0"
+					 Height="4"
+					 MinHeight="4"
+					 VerticalAlignment="Bottom"
+					 Background="Transparent"
+					 BorderThickness="0"
+					 Minimum="0"
+					 Maximum="100"
+					 Value="{Binding DaemonSyncProgress}"
+					 IsVisible="{Binding IsDaemonSyncing}"
+					 ToolTip.Tip="Daemon is downloading the blockchain"/>
+
+		<Label Name="lblWalletStatus"
+			   Grid.Row="1"
+			   Grid.Column="1"
 			   Margin="10,0,0,0"
 			   Content="{Binding WalletStatus}"/>
+		<Label Name="lblWalletStatusShort"
+			   Grid.Row="1"
+			   Grid.Column="1"
+			   Margin="10,0,0,0"
+			   IsVisible="False"
+			   Content="{Binding WalletStatusShort}"/>
+		<ProgressBar Grid.Row="1"
+					 Grid.Column="1"
+					 Margin="10,0,0,0"
+					 Height="4"
+					 MinHeight="4"
+					 VerticalAlignment="Bottom"
+					 Background="Transparent"
+					 BorderThickness="0"
+					 Minimum="0"
+					 Maximum="100"
+					 Value="{Binding WalletSyncProgress}"
+					 IsVisible="{Binding IsWalletSyncing}"
+					 ToolTip.Tip="Wallet is scanning the blockchain"/>
 	</Grid>
 	
 </UserControl>

--- a/NervaOneWalletMiner/Views/StatusBarView.axaml.cs
+++ b/NervaOneWalletMiner/Views/StatusBarView.axaml.cs
@@ -15,7 +15,36 @@ namespace NervaOneWalletMiner.Views
             catch (Exception ex)
             {
                 Logger.LogException("STB.CONS", ex);
-            }            
+            }
+        }
+
+        private void StatusBarView_SizeChanged(object? sender, SizeChangedEventArgs e)
+        {
+            try
+            {
+                // Status bar spans the whole window while the other views sit inside the SplitView content, so this is
+                // the 450 breakpoint used elsewhere plus the compact pane and content margin they lose
+                if (e.NewSize.Width < 520)
+                {
+                    // Narrow: abbreviated height, percent instead of raw heights while syncing
+                    lblDaemonStatus.IsVisible = false;
+                    lblDaemonStatusShort.IsVisible = true;
+                    lblWalletStatus.IsVisible = false;
+                    lblWalletStatusShort.IsVisible = true;
+                }
+                else
+                {
+                    // Wide: full wording and both heights
+                    lblDaemonStatus.IsVisible = true;
+                    lblDaemonStatusShort.IsVisible = false;
+                    lblWalletStatus.IsVisible = true;
+                    lblWalletStatusShort.IsVisible = false;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("STB.SBSC", ex);
+            }
         }
     }
 }


### PR DESCRIPTION
- Add thin progress bars to both status bar rows for daemon blockchain download and wallet scan
- Make the status bar responsive like the other views: full wording at 520px and above, abbreviated below