### PR TITLE
Fix wallet close on node switch and BTC open timeout

### DIFF
--- a/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
+++ b/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
@@ -5,8 +5,8 @@
     <SupportedOSPlatformVersion>26</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ApplicationId>one.nerva.android</ApplicationId>
-    <ApplicationVersion>1301</ApplicationVersion>
-    <ApplicationDisplayVersion>1.3.1</ApplicationDisplayVersion>
+    <ApplicationVersion>1302</ApplicationVersion>
+    <ApplicationDisplayVersion>1.3.2</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidEnableProfiledAot>False</AndroidEnableProfiledAot>
     <RuntimeIdentifiers>android-arm64</RuntimeIdentifiers>

--- a/NervaOneWalletMiner/Helpers/GlobalData.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalData.cs
@@ -17,7 +17,7 @@ namespace NervaOneWalletMiner.Helpers
     {
         public const string AppNameMain = "NervaOne";
         public const string AppAssemblyName = "NervaOneWalletMiner";
-        public const string Version = "1.3.1";
+        public const string Version = "1.3.2";
 
         public const string CliToolsDirName = "cli";
         public const string WalletDirName = "wallets";

--- a/NervaOneWalletMiner/Helpers/GlobalMethods.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalMethods.cs
@@ -1349,9 +1349,9 @@ namespace NervaOneWalletMiner.Helpers
             return progress > 100d ? 100d : progress;
         }
 
-        // Floor rather than round so a wallet at 99.6% does not display 100% before it is actually done
+        // One decimal because the last whole percent takes a long time. Floored so 99.99% never displays as 100%
         public static string GetSyncProgressText(double progress) =>
-            Math.Floor(progress).ToString("0") + "%";
+            (Math.Floor(progress * 10d) / 10d).ToString("0.0") + "%";
 
         public static string GetShorterString(string? text, int shorterLength)
         {
@@ -1604,7 +1604,7 @@ namespace NervaOneWalletMiner.Helpers
                     WalletName = GlobalData.OpenedWalletName
                 };
 
-                _ = await GlobalData.WalletService.CloseWallet(GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].Rpc, request);
+                _ = await GlobalData.WalletService.CloseWallet(GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].Rpc, request);
             }
             catch (Exception ex)
             {

--- a/NervaOneWalletMiner/Helpers/MasterProcess.cs
+++ b/NervaOneWalletMiner/Helpers/MasterProcess.cs
@@ -90,6 +90,9 @@ namespace NervaOneWalletMiner.Helpers
                     // Client tools downloaded and found
                     Logger.LogDebug("MSP.MUPS", "Client tools found.");
                     GlobalData.DaemonState = DaemonState.Connecting;
+
+                    // Tools update stopped both processes, so run upkeep now instead of waiting up to a health check
+                    _cliToolsRunningLastCheck = DateTime.MinValue;
                 }
 
                 // If kill master process is issued at any point, skip everything else and do not restart master timer

--- a/NervaOneWalletMiner/Rpc/Common/HttpHelper.cs
+++ b/NervaOneWalletMiner/Rpc/Common/HttpHelper.cs
@@ -37,7 +37,8 @@ namespace NervaOneWalletMiner.Rpc.Common
 
         public static async Task<HttpResponseMessage> GetPostFromService(string serviceUrl, string postContent, TimeSpan timeout)
         {
-            HttpResponseMessage response = new HttpResponseMessage();
+            // Default to failure. A default constructed HttpResponseMessage is 200 OK, which callers read as success
+            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
 
             try
             {
@@ -70,7 +71,8 @@ namespace NervaOneWalletMiner.Rpc.Common
 
         public static async Task<HttpResponseMessage> GetPostFromService(string serviceUrl, string postContent, string userName, string password, TimeSpan timeout)
         {
-            HttpResponseMessage response = new HttpResponseMessage();
+            // Default to failure. A default constructed HttpResponseMessage is 200 OK, which callers read as success
+            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
 
             try
             {
@@ -108,7 +110,8 @@ namespace NervaOneWalletMiner.Rpc.Common
 
         public static async Task<HttpResponseMessage> GetPostFromServiceDigestAuth(RpcBase rpc, string path, string postContent, TimeSpan timeout)
         {
-            HttpResponseMessage response = new HttpResponseMessage();
+            // Default to failure. A default constructed HttpResponseMessage is 200 OK, which callers read as success
+            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
 
             try
             {

--- a/NervaOneWalletMiner/Rpc/Wallet/Coins/BtcBased/WalletServiceBaseBTC.cs
+++ b/NervaOneWalletMiner/Rpc/Wallet/Coins/BtcBased/WalletServiceBaseBTC.cs
@@ -119,8 +119,8 @@ namespace NervaOneWalletMiner.Rpc.Wallet
                     ["params"] = requestParams
                 };
 
-                // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
+                // Call service and process response. loadwallet rescans when the wallet has been idle, so it needs the scan timeout
+                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password, _blockchainScanTimeout);
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     JObject jsonObject = JObject.Parse(await httpResponse.Content.ReadAsStringAsync());

--- a/NervaOneWalletMiner/ViewModels/DaemonSetupViewModel.cs
+++ b/NervaOneWalletMiner/ViewModels/DaemonSetupViewModel.cs
@@ -333,6 +333,14 @@ namespace NervaOneWalletMiner.ViewModels
             try
             {
                 Logger.LogDebug("DSM.RWCM", "Restarting with command");
+
+                // Wallet lives in the process being stopped, so close it or the UI keeps showing it as open
+                if (GlobalData.IsWalletOpen)
+                {
+                    Logger.LogDebug("DSM.RWCM", "Closing wallet: " + GlobalData.OpenedWalletName);
+                    await ((WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet]).CloseWalletNonUi();
+                }
+
                 ProcessManager.Kill(GlobalData.WalletProcessName);
                 await Task.Run(() => GlobalMethods.StopAndCloseDaemon());
 
@@ -357,6 +365,10 @@ namespace NervaOneWalletMiner.ViewModels
                         GlobalMethods.GetDaemonProcess(),
                         GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].GenerateDaemonOptions(GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin]) + " " + restartOptions);
                 }
+
+                // Run the master upkeep on the next tick instead of waiting up to a health check, so the wallet RPC
+                // comes back quickly. Otherwise a wallet open right after the switch fails against a process not up yet
+                MasterProcess._cliToolsRunningLastCheck = DateTime.MinValue;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
- Close the open wallet on a node type switch and nudge the master loop so the wallet RPC comes back right after
- Use the wallet RPC, not the daemon, when force closing a wallet
- Give BTC loadwallet the long scan timeout so an idle wallet can rescan
- Default HttpResponseMessage to a failure status so transport errors report a real error instead of a blank one
- Show sync percent to one decimal