### PR TITLE
Add Test Connection button for remote node in wallet-only setup

### DIFF
--- a/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
+++ b/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
@@ -5,8 +5,8 @@
     <SupportedOSPlatformVersion>26</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ApplicationId>one.nerva.android</ApplicationId>
-    <ApplicationVersion>1302</ApplicationVersion>
-    <ApplicationDisplayVersion>1.3.2</ApplicationDisplayVersion>
+    <ApplicationVersion>1303</ApplicationVersion>
+    <ApplicationDisplayVersion>1.3.3</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidEnableProfiledAot>False</AndroidEnableProfiledAot>
     <RuntimeIdentifiers>android-arm64</RuntimeIdentifiers>

--- a/NervaOneWalletMiner/Helpers/GlobalData.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalData.cs
@@ -17,7 +17,7 @@ namespace NervaOneWalletMiner.Helpers
     {
         public const string AppNameMain = "NervaOne";
         public const string AppAssemblyName = "NervaOneWalletMiner";
-        public const string Version = "1.3.2";
+        public const string Version = "1.3.3";
 
         public const string CliToolsDirName = "cli";
         public const string WalletDirName = "wallets";

--- a/NervaOneWalletMiner/Rpc/Daemon/Coins/BtcBased/DaemonServiceBaseBTC.cs
+++ b/NervaOneWalletMiner/Rpc/Daemon/Coins/BtcBased/DaemonServiceBaseBTC.cs
@@ -111,7 +111,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
         #endregion // Stop Daemon
 
         #region Get Info
-        public virtual async Task<GetInfoResponse> GetInfo(RpcBase rpc, GetInfoRequest requestObj)
+        public virtual async Task<GetInfoResponse> GetInfo(RpcBase rpc, GetInfoRequest requestObj, TimeSpan? timeout = null)
         {
             GetInfoResponse responseObj = new();
 
@@ -126,7 +126,10 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                     ["params"] = new JObject()
                 };
 
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
+                string serviceUrl = HttpHelper.GetServiceUrl(rpc, string.Empty);
+                HttpResponseMessage httpResponse = timeout.HasValue
+                    ? await HttpHelper.GetPostFromService(serviceUrl, requestJson.ToString(), rpc.UserName, rpc.Password, timeout.Value)
+                    : await HttpHelper.GetPostFromService(serviceUrl, requestJson.ToString(), rpc.UserName, rpc.Password);
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     string responseContent = await httpResponse.Content.ReadAsStringAsync();
@@ -194,7 +197,9 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                         ["params"] = new JObject()
                     };
 
-                    httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, string.Empty), requestJson.ToString(), rpc.UserName, rpc.Password);
+                    httpResponse = timeout.HasValue
+                        ? await HttpHelper.GetPostFromService(serviceUrl, requestJson.ToString(), rpc.UserName, rpc.Password, timeout.Value)
+                        : await HttpHelper.GetPostFromService(serviceUrl, requestJson.ToString(), rpc.UserName, rpc.Password);
                     if (httpResponse.IsSuccessStatusCode)
                     {
                         string responseContent = await httpResponse.Content.ReadAsStringAsync();

--- a/NervaOneWalletMiner/Rpc/Daemon/Coins/XmrBased/DaemonServiceBaseXMR.cs
+++ b/NervaOneWalletMiner/Rpc/Daemon/Coins/XmrBased/DaemonServiceBaseXMR.cs
@@ -196,7 +196,7 @@ namespace NervaOneWalletMiner.Rpc.Daemon
         #endregion // Stop Daemon
 
         #region Get Info
-        public async Task<GetInfoResponse> GetInfo(RpcBase rpc, GetInfoRequest requestObj)
+        public async Task<GetInfoResponse> GetInfo(RpcBase rpc, GetInfoRequest requestObj, TimeSpan? timeout = null)
         {
             GetInfoResponse responseObj = new();
 
@@ -211,7 +211,10 @@ namespace NervaOneWalletMiner.Rpc.Daemon
                 };
 
                 // Call service and process response
-                HttpResponseMessage httpResponse = await HttpHelper.GetPostFromService(HttpHelper.GetServiceUrl(rpc, "json_rpc"), requestJson.ToString());
+                string serviceUrl = HttpHelper.GetServiceUrl(rpc, "json_rpc");
+                HttpResponseMessage httpResponse = timeout.HasValue
+                    ? await HttpHelper.GetPostFromService(serviceUrl, requestJson.ToString(), timeout.Value)
+                    : await HttpHelper.GetPostFromService(serviceUrl, requestJson.ToString());
                 if (httpResponse.IsSuccessStatusCode)
                 {
                     string responseContent = await httpResponse.Content.ReadAsStringAsync();

--- a/NervaOneWalletMiner/Rpc/Daemon/IDaemonService.cs
+++ b/NervaOneWalletMiner/Rpc/Daemon/IDaemonService.cs
@@ -1,6 +1,7 @@
 ﻿using NervaOneWalletMiner.Rpc.Common;
 using NervaOneWalletMiner.Rpc.Daemon.Requests;
 using NervaOneWalletMiner.Rpc.Daemon.Responses;
+using System;
 using System.Threading.Tasks;
 
 namespace NervaOneWalletMiner.Rpc.Daemon
@@ -13,7 +14,8 @@ namespace NervaOneWalletMiner.Rpc.Daemon
         
         Task<StopDaemonResponse> StopDaemon(RpcBase rpc, StopDaemonRequest requestObj);
 
-        Task<GetInfoResponse> GetInfo(RpcBase rpc, GetInfoRequest requestObj);
+        // timeout overrides the default so a connection test can fail fast instead of hanging
+        Task<GetInfoResponse> GetInfo(RpcBase rpc, GetInfoRequest requestObj, TimeSpan? timeout = null);
 
         Task<GetConnectionsResponse> GetConnections(RpcBase rpc, GetConnectionsRequest requestObj);
 

--- a/NervaOneWalletMiner/Views/DaemonSetupView.axaml
+++ b/NervaOneWalletMiner/Views/DaemonSetupView.axaml
@@ -74,6 +74,10 @@
 						   Margin="0,10,0,10"/>
 				<TextBox Name="tbxRemoteNode"
 						 Text="{Binding RemoteNodeAddress, Mode=TwoWay}"/>
+				<Button Name="btnTestConnection"
+						Content="Test Connection"
+						Margin="0,10,0,0"
+						Click="TestConnection_Clicked"/>
 			</StackPanel>
 
 			<StackPanel Name="spFullNode" IsVisible="{Binding IsLocalNode}">

--- a/NervaOneWalletMiner/Views/DaemonSetupView.axaml.cs
+++ b/NervaOneWalletMiner/Views/DaemonSetupView.axaml.cs
@@ -3,6 +3,9 @@ using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using NervaOneWalletMiner.Helpers;
 using NervaOneWalletMiner.Objects;
+using NervaOneWalletMiner.Rpc.Common;
+using NervaOneWalletMiner.Rpc.Daemon.Requests;
+using NervaOneWalletMiner.Rpc.Daemon.Responses;
 using NervaOneWalletMiner.ViewModels;
 using NervaOneWalletMiner.ViewsDialogs;
 using System;
@@ -126,6 +129,81 @@ namespace NervaOneWalletMiner.Views
             }
         }
         #endregion // Restart With QuickSync
+
+        #region Test Connection
+        public async void TestConnection_Clicked(object sender, RoutedEventArgs args)
+        {
+            try
+            {
+                string address = GetVm().RemoteNodeAddress.Trim();
+
+                if (string.IsNullOrEmpty(address))
+                {
+                    await DialogService.ShowAsync(new MessageBoxView("Test Connection", "Enter a remote node address first.", true));
+                    return;
+                }
+
+                if (!TryParseNodeAddress(address, out string host, out int port))
+                {
+                    await DialogService.ShowAsync(new MessageBoxView("Test Connection", "Enter the address as host or IP with a port number, for example 1.2.3.4:" + GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].DaemonPort, true));
+                    return;
+                }
+
+                // Test the daemon directly since a wallet can open locally even when the node is unreachable
+                btnTestConnection.IsEnabled = false;
+                btnTestConnection.Content = "Testing...";
+
+                RpcBase rpc = new() { Host = host, Port = port };
+                GetInfoResponse response = await GlobalData.DaemonService.GetInfo(rpc, new GetInfoRequest(), TimeSpan.FromSeconds(10));
+
+                btnTestConnection.Content = "Test Connection";
+                btnTestConnection.IsEnabled = true;
+
+                if (response.Error.IsError)
+                {
+                    Logger.LogError("DMS.TCON", "Test connection failed for " + host + ":" + port + " | Code: " + response.Error.Code + " | Message: " + response.Error.Message + " | Content: " + response.Error.Content);
+                    await DialogService.ShowAsync(new MessageBoxView("Test Connection", "Could not connect to " + host + ":" + port + ".\r\n\r\nMake sure the node is running and the port is open and forwarded.", true));
+                }
+                else
+                {
+                    Logger.LogDebug("DMS.TCON", "Test connection succeeded for " + host + ":" + port + " | Version: " + response.Version);
+
+                    // Public/restricted nodes blank the version in get_info, so only show it when the node returns one
+                    string versionLine = string.IsNullOrEmpty(response.Version) ? string.Empty : "Version: " + response.Version + "\r\n";
+                    await DialogService.ShowAsync(new MessageBoxView("Test Connection", "Connected successfully.\r\n\r\n" + versionLine + "Height: " + response.Height, true));
+                }
+            }
+            catch (Exception ex)
+            {
+                btnTestConnection.Content = "Test Connection";
+                btnTestConnection.IsEnabled = true;
+                Logger.LogException("DMS.TCON", ex);
+            }
+        }
+
+        // Parses host:port, with an optional http(s):// scheme. Expects a single colon, so IPv6 is not supported
+        private static bool TryParseNodeAddress(string address, out string host, out int port)
+        {
+            host = string.Empty;
+            port = 0;
+
+            if (address.Contains("://"))
+            {
+                address = address[(address.IndexOf("://") + 3)..];
+            }
+
+            address = address.Trim('/');
+
+            int lastColon = address.LastIndexOf(':');
+            if (lastColon <= 0 || lastColon == address.Length - 1)
+            {
+                return false;
+            }
+
+            host = address[..lastColon];
+            return int.TryParse(address[(lastColon + 1)..], out port) && port > 0 && port <= 65535;
+        }
+        #endregion // Test Connection
 
         #region Public Node Setup
         public void PublicNodeSetup_Clicked(object sender, RoutedEventArgs args)


### PR DESCRIPTION
- Add a Test Connection button under the remote node address that runs get_info against the entered node and reports success with height, or a failure message
- Add an optional timeout to GetInfo so the test fails fast instead of waiting the default timeout
- Log full error detail on a failed test for troubleshooting