### PR TITLE
Add empty state to Wallet and Transfers screens

### DIFF
--- a/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
+++ b/NervaOneWalletMiner.Android/NervaOneWalletMiner.Android.csproj
@@ -5,8 +5,8 @@
     <SupportedOSPlatformVersion>26</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ApplicationId>one.nerva.android</ApplicationId>
-    <ApplicationVersion>1303</ApplicationVersion>
-    <ApplicationDisplayVersion>1.3.3</ApplicationDisplayVersion>
+    <ApplicationVersion>1304</ApplicationVersion>
+    <ApplicationDisplayVersion>1.3.4</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidEnableProfiledAot>False</AndroidEnableProfiledAot>
     <RuntimeIdentifiers>android-arm64</RuntimeIdentifiers>

--- a/NervaOneWalletMiner/Helpers/GlobalData.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalData.cs
@@ -17,7 +17,7 @@ namespace NervaOneWalletMiner.Helpers
     {
         public const string AppNameMain = "NervaOne";
         public const string AppAssemblyName = "NervaOneWalletMiner";
-        public const string Version = "1.3.3";
+        public const string Version = "1.3.4";
 
         public const string CliToolsDirName = "cli";
         public const string WalletDirName = "wallets";

--- a/NervaOneWalletMiner/Helpers/GlobalMethods.cs
+++ b/NervaOneWalletMiner/Helpers/GlobalMethods.cs
@@ -155,6 +155,38 @@ namespace NervaOneWalletMiner.Helpers
             return walletDirectory;
         }
 
+        // Names of wallets that exist on disk for active coin. Some coins store wallet as directory, others as file
+        public static List<string> GetWalletFileNames()
+        {
+            List<string> wallets = [];
+
+            try
+            {
+                DirectoryInfo walletsDir = new(GetWalletDir());
+                if (GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].WalletExtension.Equals("directory"))
+                {
+                    foreach (DirectoryInfo dir in walletsDir.GetDirectories())
+                    {
+                        wallets.Add(dir.Name);
+                    }
+                }
+                else
+                {
+                    FileInfo[] files = walletsDir.GetFiles("*" + GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].WalletExtension, SearchOption.TopDirectoryOnly);
+                    foreach (FileInfo file in files)
+                    {
+                        wallets.Add(Path.GetFileNameWithoutExtension(file.FullName));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("GLM.GWFN", ex);
+            }
+
+            return wallets;
+        }
+
         public static string GetCliToolsDir()
         {
             string cliToolsDirectory = string.Empty;

--- a/NervaOneWalletMiner/Helpers/UIManager.cs
+++ b/NervaOneWalletMiner/Helpers/UIManager.cs
@@ -31,6 +31,13 @@ namespace NervaOneWalletMiner.Helpers
 
         private static ViewModelBase _mainView = new();
 
+        // Wallet and Transfers empty states both need to know if any wallets exist on disk. Master timer
+        // runs every few seconds so directory is scanned periodically, and right away when wallet closes
+        private static readonly int _walletFilesScanSeconds = 10;
+        private static DateTime _lastWalletFilesScan = DateTime.MinValue;
+        private static volatile bool _isWalletFilesScanNeeded = true;
+        private static volatile int _walletFilesCount = 0;
+
 
         // TODO: I don't like this. Come up with a different way
         public static void SetMainView(ViewModelBase mainView)
@@ -521,6 +528,97 @@ namespace NervaOneWalletMiner.Helpers
             }
         }
         
+        // Cached so Wallet and Transfers updates in same timer tick do not both hit the file system
+        private static int GetWalletFilesCount()
+        {
+            if (_isWalletFilesScanNeeded || _lastWalletFilesScan.AddSeconds(_walletFilesScanSeconds) < DateTime.Now)
+            {
+                _isWalletFilesScanNeeded = false;
+                _lastWalletFilesScan = DateTime.Now;
+                _walletFilesCount = GlobalMethods.GetWalletFileNames().Count;
+            }
+
+            return _walletFilesCount;
+        }
+
+        // Message and button to show on Wallet page when no wallet is open. Brand new users have no wallets
+        // and need to create one. Everyone else just needs to open one of theirs
+        private static (bool IsNoWallets, string Message) GetWalletEmptyState()
+        {
+            int walletCount = GetWalletFilesCount();
+            string message;
+
+            if (walletCount == 0)
+            {
+                message = "You do not have a wallet yet.\r\n\r\nCreate a new wallet or restore an existing one to get started.";
+            }
+            else if (walletCount == 1)
+            {
+                message = "Your wallet is closed.\r\n\r\nOpen it to see your balance and addresses.";
+            }
+            else
+            {
+                message = "You have " + walletCount + " wallets.\r\n\r\nOpen one to see your balance and addresses.";
+            }
+
+            return (walletCount == 0, message);
+        }
+
+        // Transfers has nothing to show without an open wallet either, but opening one lives on Wallet page
+        // so users are pointed there instead of at Wallet Setup, unless they have no wallets at all
+        private static (bool IsNoWallets, string Message) GetTransfersEmptyState()
+        {
+            int walletCount = GetWalletFilesCount();
+            string message;
+
+            if (walletCount == 0)
+            {
+                message = "You do not have a wallet yet.\r\n\r\nSet one up to start sending and receiving.";
+            }
+            else
+            {
+                message = "No wallet is open.\r\n\r\nOpen one on Wallet screen to see your transactions.";
+            }
+
+            return (walletCount == 0, message);
+        }
+
+        // Called when Wallet page is shown so new user sees what to do next without waiting for master timer
+        public static void RefreshWalletEmptyState()
+        {
+            try
+            {
+                WalletViewModel walletVm = (WalletViewModel)GlobalData.ViewModelPages[SplitViewPages.Wallet];
+                (bool isNoWallets, string message) = GetWalletEmptyState();
+
+                walletVm.IsNoWalletsState = isNoWallets;
+                walletVm.EmptyStateMessage = message;
+                walletVm.IsEmptyStateVisible = !GlobalData.IsWalletOpen;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("UIM.RWES", ex);
+            }
+        }
+
+        // Same as above but for Transfers page
+        public static void RefreshTransfersEmptyState()
+        {
+            try
+            {
+                TransfersViewModel transfersVm = (TransfersViewModel)GlobalData.ViewModelPages[SplitViewPages.Transfers];
+                (bool isNoWallets, string message) = GetTransfersEmptyState();
+
+                transfersVm.IsNoWalletsState = isNoWallets;
+                transfersVm.EmptyStateMessage = message;
+                transfersVm.IsEmptyStateVisible = !GlobalData.IsWalletOpen;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("UIM.RTES", ex);
+            }
+        }
+
         public static void UpdateWalletView()
         {
             try
@@ -530,6 +628,9 @@ namespace NervaOneWalletMiner.Helpers
 
                 if (GlobalData.IsWalletOpen)
                 {
+                    // Wallet files will need to be rescanned as soon as this wallet closes
+                    _isWalletFilesScanNeeded = true;
+
                     // Compute collection changes on timer thread before marshaling to UI thread
                     List<Account> deleteAccounts = [];
                     List<Account> addAccounts = [];
@@ -652,7 +753,10 @@ namespace NervaOneWalletMiner.Helpers
                             }
                         }
 
-                        walletVm.OpenCloseWallet = StatusWallet.CloseWallet;
+                        if (walletVm.IsEmptyStateVisible)
+                        {
+                            walletVm.IsEmptyStateVisible = false;
+                        }
 
                         if (mainViewVm.WalletStatus != statusBarMessage)
                         {
@@ -671,6 +775,9 @@ namespace NervaOneWalletMiner.Helpers
                     // If wallet is closed/was closed by the user, clear fields
                     string totalLockedLabel = "Total " + GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].DisplayUnits + ":";
                     string totalUnlockedLabel = "Unlocked " + GlobalData.AppSettings.Wallet[GlobalData.AppSettings.ActiveCoin].DisplayUnits + ":";
+
+                    // Work out empty state on timer thread before marshaling to UI thread
+                    (bool isNoWalletsState, string emptyStateMessage) = GetWalletEmptyState();
 
                     Dispatcher.UIThread.Invoke(() =>
                     {
@@ -695,7 +802,18 @@ namespace NervaOneWalletMiner.Helpers
                             walletVm.WalletAddresses = [];
                         }
 
-                        walletVm.OpenCloseWallet = StatusWallet.OpenWallet;
+                        if (walletVm.IsNoWalletsState != isNoWalletsState)
+                        {
+                            walletVm.IsNoWalletsState = isNoWalletsState;
+                        }
+                        if (!walletVm.EmptyStateMessage.Equals(emptyStateMessage))
+                        {
+                            walletVm.EmptyStateMessage = emptyStateMessage;
+                        }
+                        if (!walletVm.IsEmptyStateVisible)
+                        {
+                            walletVm.IsEmptyStateVisible = true;
+                        }
 
                         if (mainViewVm.WalletStatus != GlobalData.WalletClosedMessage)
                         {
@@ -726,6 +844,14 @@ namespace NervaOneWalletMiner.Helpers
 
                 if (GlobalData.IsWalletOpen)
                 {
+                    if (transfersViewVm.IsEmptyStateVisible)
+                    {
+                        Dispatcher.UIThread.Invoke(() =>
+                        {
+                            transfersViewVm.IsEmptyStateVisible = false;
+                        });
+                    }
+
                     if (transfersViewVm.Transactions.Count == 0)
                     {
                         ObservableCollection<Transfer> initialTransfers = [.. GlobalData.TransfersStats.Transactions.Values];
@@ -890,6 +1016,25 @@ namespace NervaOneWalletMiner.Helpers
                 }
                 else
                 {
+                    // Work out empty state on timer thread before marshaling to UI thread
+                    (bool isNoWalletsState, string emptyStateMessage) = GetTransfersEmptyState();
+
+                    Dispatcher.UIThread.Invoke(() =>
+                    {
+                        if (transfersViewVm.IsNoWalletsState != isNoWalletsState)
+                        {
+                            transfersViewVm.IsNoWalletsState = isNoWalletsState;
+                        }
+                        if (!transfersViewVm.EmptyStateMessage.Equals(emptyStateMessage))
+                        {
+                            transfersViewVm.EmptyStateMessage = emptyStateMessage;
+                        }
+                        if (!transfersViewVm.IsEmptyStateVisible)
+                        {
+                            transfersViewVm.IsEmptyStateVisible = true;
+                        }
+                    });
+
                     // If wallet is closed/was closed by the user, clear fields
                     if (transfersViewVm.Transactions.Count != 0)
                     {

--- a/NervaOneWalletMiner/Objects/Constants/StatusWallet.cs
+++ b/NervaOneWalletMiner/Objects/Constants/StatusWallet.cs
@@ -1,8 +1,0 @@
-﻿namespace NervaOneWalletMiner.Objects.Constants
-{
-    public static class StatusWallet
-    {
-        public const string OpenWallet = "Open Wallet";
-        public const string CloseWallet = "Close Wallet";
-    }
-}

--- a/NervaOneWalletMiner/ViewModels/TransfersViewModel.cs
+++ b/NervaOneWalletMiner/ViewModels/TransfersViewModel.cs
@@ -1,5 +1,4 @@
-﻿using NervaOneWalletMiner.Objects.Constants;
-using NervaOneWalletMiner.Objects.DataGrid;
+﻿using NervaOneWalletMiner.Objects.DataGrid;
 using ReactiveUI;
 using System.Collections.ObjectModel;
 
@@ -7,11 +6,28 @@ namespace NervaOneWalletMiner.ViewModels
 {
     internal class TransfersViewModel : ViewModelBase
     {
-        private string _OpenCloseWallet = StatusWallet.OpenWallet;
-        public string OpenCloseWallet
+        // Empty state replaces transactions grid when no wallet is open, same as on Wallet screen.
+        // UIManager.UpdateTransfersView keeps these in sync
+        private bool _IsEmptyStateVisible = true;
+        public bool IsEmptyStateVisible
         {
-            get => _OpenCloseWallet;
-            set => this.RaiseAndSetIfChanged(ref _OpenCloseWallet, value);
+            get => _IsEmptyStateVisible;
+            set => this.RaiseAndSetIfChanged(ref _IsEmptyStateVisible, value);
+        }
+
+        private string _EmptyStateMessage = string.Empty;
+        public string EmptyStateMessage
+        {
+            get => _EmptyStateMessage;
+            set => this.RaiseAndSetIfChanged(ref _EmptyStateMessage, value);
+        }
+
+        // True when user has no wallets at all, which means Wallet Setup instead of Wallet screen
+        private bool _IsNoWalletsState = false;
+        public bool IsNoWalletsState
+        {
+            get => _IsNoWalletsState;
+            set => this.RaiseAndSetIfChanged(ref _IsNoWalletsState, value);
         }
 
         private ObservableCollection<Transfer> _Transactions = [];

--- a/NervaOneWalletMiner/ViewModels/WalletViewModel.cs
+++ b/NervaOneWalletMiner/ViewModels/WalletViewModel.cs
@@ -1,5 +1,4 @@
-﻿using NervaOneWalletMiner.Objects.Constants;
-using NervaOneWalletMiner.Objects.DataGrid;
+﻿using NervaOneWalletMiner.Objects.DataGrid;
 using ReactiveUI;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
@@ -22,13 +21,6 @@ namespace NervaOneWalletMiner.ViewModels
             return CloseWalletNonUiEvent!.Invoke();
         }
 
-
-        private string _OpenCloseWallet = StatusWallet.OpenWallet;
-        public string OpenCloseWallet
-        {
-            get => _OpenCloseWallet;
-            set => this.RaiseAndSetIfChanged(ref _OpenCloseWallet, value);
-        }
 
         private string _TotalCoins = string.Empty;
         public string TotalCoins
@@ -56,6 +48,30 @@ namespace NervaOneWalletMiner.ViewModels
         {
             get => _TotalUnlockedLabel;
             set => this.RaiseAndSetIfChanged(ref _TotalUnlockedLabel, value);
+        }
+
+        // Empty state replaces accounts grid when no wallet is open. It tells new users what to do next
+        // instead of leaving them looking at empty grid. UIManager.UpdateWalletView keeps these in sync
+        private bool _IsEmptyStateVisible = true;
+        public bool IsEmptyStateVisible
+        {
+            get => _IsEmptyStateVisible;
+            set => this.RaiseAndSetIfChanged(ref _IsEmptyStateVisible, value);
+        }
+
+        private string _EmptyStateMessage = string.Empty;
+        public string EmptyStateMessage
+        {
+            get => _EmptyStateMessage;
+            set => this.RaiseAndSetIfChanged(ref _EmptyStateMessage, value);
+        }
+
+        // True when user has no wallets at all, which means they need Create/Restore instead of Open
+        private bool _IsNoWalletsState = false;
+        public bool IsNoWalletsState
+        {
+            get => _IsNoWalletsState;
+            set => this.RaiseAndSetIfChanged(ref _IsNoWalletsState, value);
         }
 
         private ObservableCollection<Account> _WalletAddresses = new();

--- a/NervaOneWalletMiner/Views/OpenWalletView.axaml.cs
+++ b/NervaOneWalletMiner/Views/OpenWalletView.axaml.cs
@@ -8,8 +8,6 @@ using NervaOneWalletMiner.Rpc.Wallet.Requests;
 using NervaOneWalletMiner.Rpc.Wallet.Responses;
 using NervaOneWalletMiner.ViewsDialogs;
 using System;
-using System.Collections.Generic;
-using System.IO;
 
 namespace NervaOneWalletMiner.Views
 {
@@ -30,7 +28,7 @@ namespace NervaOneWalletMiner.Views
                     btnShowHidePassword.IsEnabled = false;
                 }
 
-                cbxWalletName.ItemsSource = GetWalletFileNames();
+                cbxWalletName.ItemsSource = GlobalMethods.GetWalletFileNames();
                 cbxWalletName.SelectedIndex = 0;
 
                 Loaded += (_, _) => cbxWalletName.Focus();
@@ -39,37 +37,6 @@ namespace NervaOneWalletMiner.Views
             {
                 Logger.LogException("OWV.CONS", ex);
             }
-        }
-
-        private List<string> GetWalletFileNames()
-        {
-            List<string> wallets = [];
-
-            try
-            {
-                DirectoryInfo walletsDir = new(GlobalMethods.GetWalletDir());
-                if (GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].WalletExtension.Equals("directory"))
-                {
-                    foreach (DirectoryInfo dir in walletsDir.GetDirectories())
-                    {
-                        wallets.Add(dir.Name);
-                    }
-                }
-                else
-                {
-                    FileInfo[] files = walletsDir.GetFiles("*" + GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].WalletExtension, SearchOption.TopDirectoryOnly);
-                    foreach (FileInfo file in files)
-                    {
-                        wallets.Add(Path.GetFileNameWithoutExtension(file.FullName));
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.LogException("OWV.GWFN", ex);
-            }
-
-            return wallets;
         }
 
         public void Password_KeyDown(object sender, KeyEventArgs args)

--- a/NervaOneWalletMiner/Views/TransfersView.axaml
+++ b/NervaOneWalletMiner/Views/TransfersView.axaml
@@ -32,16 +32,56 @@
 						   Height="24" Margin="5,0,0,0"/>
 				</Grid>
 
+				<!-- Nothing to get details on while empty state is up -->
 				<Button Grid.Row="0" Grid.Column="2"
 						Name="btnTransactionDetails"
 						Content="Transaction Details"
+						IsVisible="{Binding !IsEmptyStateVisible}"
 						Margin="0,0,5,0"
 						Click="TransactionDetails_Clicked"/>
 			</Grid>
 		</StackPanel>
 
+		<!-- Shown instead of transactions grid when no wallet is open. Wallets are opened on Wallet
+			 screen, so that is where users are sent unless they have no wallets at all -->
+		<ScrollViewer Grid.Row="1"
+					  Name="scrEmptyState"
+					  IsVisible="{Binding IsEmptyStateVisible}">
+			<StackPanel Name="spEmptyState"
+						Spacing="15"
+						Margin="20"
+						MaxWidth="650"
+						VerticalAlignment="Center">
+
+				<TextBlock Name="tbkEmptyState"
+						   Text="{Binding EmptyStateMessage}"
+						   TextWrapping="Wrap"
+						   TextAlignment="Center"/>
+
+				<!-- Only one of these is ever visible -->
+				<StackPanel Name="spEmptyStateButtons"
+							Spacing="10"
+							HorizontalAlignment="Center">
+					<Button Name="btnEmptySetUpWallet"
+							Content="Go to Wallet Setup"
+							MinWidth="120"
+							HorizontalContentAlignment="Center"
+							IsVisible="{Binding IsNoWalletsState}"
+							Click="EmptySetUpWallet_Clicked"/>
+					<Button Name="btnEmptyGoToWallet"
+							Content="Go to Wallet"
+							MinWidth="120"
+							HorizontalContentAlignment="Center"
+							IsVisible="{Binding !IsNoWalletsState}"
+							Click="EmptyGoToWallet_Clicked"/>
+				</StackPanel>
+
+			</StackPanel>
+		</ScrollViewer>
+
 		<DataGrid Grid.Row="1" ItemsSource="{Binding Transactions}"
 					  Name="dtgTransactions"
+					  IsVisible="{Binding !IsEmptyStateVisible}"
 					  AutoGenerateColumns="False"
 					  GridLinesVisibility="Horizontal"
 					  IsReadOnly="True"

--- a/NervaOneWalletMiner/Views/TransfersView.axaml.cs
+++ b/NervaOneWalletMiner/Views/TransfersView.axaml.cs
@@ -1,8 +1,10 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Layout;
 using Avalonia.Threading;
 using NervaOneWalletMiner.Helpers;
+using NervaOneWalletMiner.Objects.Constants;
 using NervaOneWalletMiner.Objects.DataGrid;
 using NervaOneWalletMiner.Rpc.Wallet.Requests;
 using NervaOneWalletMiner.Rpc.Wallet.Responses;
@@ -34,12 +36,65 @@ namespace NervaOneWalletMiner.Views
                     RequestBringIntoViewEvent,
                     (object? sender, RequestBringIntoViewEventArgs e) => { e.Handled = true; },
                     RoutingStrategies.Bubble);
+
+                Initialized += TransfersView_Initialized;
             }
             catch (Exception ex)
             {
                 Logger.LogException("TRA.CONS", ex);
             }
         }
+
+        private void TransfersView_Initialized(object? sender, EventArgs e)
+        {
+            try
+            {
+                // Master timer refreshes this too but that can take a few seconds
+                UIManager.RefreshTransfersEmptyState();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("TRA.TRVI", ex);
+            }
+        }
+
+        #region Empty State
+        // Wallets are created and restored on Wallet Setup, and opened on Wallet screen. Transfers has
+        // nothing of its own to offer here, so it just points at whichever one user needs
+        public void EmptySetUpWallet_Clicked(object sender, RoutedEventArgs args)
+        {
+            try
+            {
+                Logger.LogDebug("TRA.ESWC", "Navigating to Wallet Setup page");
+                UIManager.NavigateToPage(SplitViewPages.WalletSetup);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("TRA.ESWC", ex);
+            }
+        }
+
+        public void EmptyGoToWallet_Clicked(object sender, RoutedEventArgs args)
+        {
+            try
+            {
+                Logger.LogDebug("TRA.EGWC", "Navigating to Wallet page");
+                UIManager.NavigateToPage(SplitViewPages.Wallet);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("TRA.EGWC", ex);
+            }
+        }
+
+        // Alignment has to be set on buttons themselves. Setting it on their panel is not enough as
+        // buttons keep their own width and end up sitting off to the side of centered message
+        private void SetEmptyStateButtonAlignment(HorizontalAlignment alignment)
+        {
+            btnEmptySetUpWallet.HorizontalAlignment = alignment;
+            btnEmptyGoToWallet.HorizontalAlignment = alignment;
+        }
+        #endregion // Empty State
 
         private void TransfersView_SizeChanged(object? sender, SizeChangedEventArgs e)
         {
@@ -57,6 +112,12 @@ namespace NervaOneWalletMiner.Views
                     if (_colHeight != null) { _colHeight.IsVisible = false; }
                     if (_colConf != null) { _colConf.IsVisible = false; }
                     if (_colAddress != null) { _colAddress.IsVisible = false; }
+
+                    // Narrow: full width empty state button, anchored to top so it stays put instead of
+                    // floating in middle of a tall phone screen
+                    spEmptyState.VerticalAlignment = VerticalAlignment.Top;
+                    spEmptyStateButtons.HorizontalAlignment = HorizontalAlignment.Stretch;
+                    SetEmptyStateButtonAlignment(HorizontalAlignment.Stretch);
                 }
                 else if (e.NewSize.Width < 700)
                 {
@@ -70,6 +131,11 @@ namespace NervaOneWalletMiner.Views
                     if (_colHeight != null) { _colHeight.IsVisible = true; }
                     if (_colConf != null) { _colConf.IsVisible = true; }
                     if (_colAddress != null) { _colAddress.IsVisible = false; }
+
+                    // Medium: empty state button centered
+                    spEmptyState.VerticalAlignment = VerticalAlignment.Center;
+                    spEmptyStateButtons.HorizontalAlignment = HorizontalAlignment.Center;
+                    SetEmptyStateButtonAlignment(HorizontalAlignment.Center);
                 }
                 else
                 {
@@ -83,6 +149,11 @@ namespace NervaOneWalletMiner.Views
                     if (_colHeight != null) { _colHeight.IsVisible = true; }
                     if (_colConf != null) { _colConf.IsVisible = true; }
                     if (_colAddress != null) { _colAddress.IsVisible = true; }
+
+                    // Wide: empty state button centered
+                    spEmptyState.VerticalAlignment = VerticalAlignment.Center;
+                    spEmptyStateButtons.HorizontalAlignment = HorizontalAlignment.Center;
+                    SetEmptyStateButtonAlignment(HorizontalAlignment.Center);
                 }
             }
             catch (Exception ex)

--- a/NervaOneWalletMiner/Views/WalletView.axaml
+++ b/NervaOneWalletMiner/Views/WalletView.axaml
@@ -33,16 +33,21 @@
 							   Height="24" Margin="5,0,0,0"/>
 					</Grid>
 
-					<!-- Component 2: Open/Close Wallet button -->
+					<!-- Component 2: Close Wallet button. Only shown while a wallet is open, which is exactly
+						 when empty state is hidden. Opening is done from empty state instead -->
 					<Button Grid.Row="0" Grid.Column="2"
-							Name="btnOpenCloseWallet"
-							Content="{Binding OpenCloseWallet}"														
+							Name="btnCloseWallet"
+							Content="Close Wallet"
+							IsVisible="{Binding !IsEmptyStateVisible}"
 							Width="120"
-							Margin="0,0,5,0"							
-							Click="OpenCloseWallet_Clicked"/>
+							Margin="0,0,5,0"
+							Click="CloseWallet_Clicked"/>
 				</Grid>
 
+				<!-- Balances and wallet actions are meaningless with no wallet open. Hiding them frees up
+					 vertical space for empty state, which matters on a phone -->
 				<Grid Name="grdStats"
+					  IsVisible="{Binding !IsEmptyStateVisible}"
 					  ColumnDefinitions="200,*,200" Margin="0,10,5,0">
 					<Grid.RowDefinitions>
 						<RowDefinition Height="Auto"/>
@@ -100,7 +105,46 @@
 
 		</StackPanel>
 
+		<!-- Shown instead of accounts grid when no wallet is open. ScrollViewer keeps buttons reachable
+			 on short screens, like a phone in landscape -->
+		<ScrollViewer Grid.Row="1"
+					  Name="scrEmptyState"
+					  IsVisible="{Binding IsEmptyStateVisible}">
+			<StackPanel Name="spEmptyState"
+						Spacing="15"
+						Margin="20"
+						MaxWidth="650"
+						VerticalAlignment="Center">
+
+				<TextBlock Name="tbkEmptyState"
+						   Text="{Binding EmptyStateMessage}"
+						   TextWrapping="Wrap"
+						   TextAlignment="Center"/>
+
+				<!-- Only one of these is ever visible. Create and restore both live on Wallet Setup, so
+					 new users are sent there instead of being asked to pick between them here -->
+				<StackPanel Name="spEmptyStateButtons"
+							Spacing="10"
+							HorizontalAlignment="Center">
+					<Button Name="btnEmptySetUpWallet"
+							Content="Go to Wallet Setup"
+							MinWidth="120"
+							HorizontalContentAlignment="Center"
+							IsVisible="{Binding IsNoWalletsState}"
+							Click="EmptySetUpWallet_Clicked"/>
+					<Button Name="btnEmptyOpenWallet"
+							Content="Open Wallet"
+							MinWidth="120"
+							HorizontalContentAlignment="Center"
+							IsVisible="{Binding !IsNoWalletsState}"
+							Click="EmptyOpenWallet_Clicked"/>
+				</StackPanel>
+
+			</StackPanel>
+		</ScrollViewer>
+
 		<DataGrid Grid.Row="1" Name="dtgAccounts"
+					  IsVisible="{Binding !IsEmptyStateVisible}"
 					  ItemsSource="{Binding WalletAddresses, Mode=OneWay}"
 					  GridLinesVisibility="Horizontal"
 					  AutoGenerateColumns="False"

--- a/NervaOneWalletMiner/Views/WalletView.axaml.cs
+++ b/NervaOneWalletMiner/Views/WalletView.axaml.cs
@@ -59,11 +59,11 @@ namespace NervaOneWalletMiner.Views
             {
                 if (e.NewSize.Width < 450)
                 {
-                    // Narrow: Open Wallet button below icon/label
+                    // Narrow: Close Wallet button below icon/label
                     grdHeader.ColumnDefinitions = ColumnDefinitions.Parse("Auto,*");
-                    Grid.SetRow(btnOpenCloseWallet, 1);
-                    Grid.SetColumn(btnOpenCloseWallet, 0);
-                    btnOpenCloseWallet.Margin = new Thickness(0, 10, 5, 0);
+                    Grid.SetRow(btnCloseWallet, 1);
+                    Grid.SetColumn(btnCloseWallet, 0);
+                    btnCloseWallet.Margin = new Thickness(0, 10, 5, 0);
 
                     // Narrow: Transfer/Address buttons below balances
                     grdStats.ColumnDefinitions = ColumnDefinitions.Parse("200,Auto");
@@ -76,14 +76,20 @@ namespace NervaOneWalletMiner.Views
                     if (_colId != null) { _colId.IsVisible = false; }
                     if (_colAddress != null) { _colAddress.IsVisible = false; }
                     if (_colUnlocked != null) { _colUnlocked.IsVisible = false; }
+
+                    // Narrow: full width empty state button, anchored to top so it stays put instead of
+                    // floating in middle of a tall phone screen
+                    spEmptyState.VerticalAlignment = VerticalAlignment.Top;
+                    spEmptyStateButtons.HorizontalAlignment = HorizontalAlignment.Stretch;
+                    SetEmptyStateButtonAlignment(HorizontalAlignment.Stretch);
                 }
                 else if (e.NewSize.Width < 700)
                 {
-                    // Medium: Open Wallet button on the right of icon/label
+                    // Medium: Close Wallet button on the right of icon/label
                     grdHeader.ColumnDefinitions = ColumnDefinitions.Parse("Auto,*,Auto");
-                    Grid.SetRow(btnOpenCloseWallet, 0);
-                    Grid.SetColumn(btnOpenCloseWallet, 2);
-                    btnOpenCloseWallet.Margin = new Thickness(0, 0, 5, 0);
+                    Grid.SetRow(btnCloseWallet, 0);
+                    Grid.SetColumn(btnCloseWallet, 2);
+                    btnCloseWallet.Margin = new Thickness(0, 0, 5, 0);
 
                     // Medium: Transfer/Address buttons on the right
                     grdStats.ColumnDefinitions = ColumnDefinitions.Parse("200,*,200");
@@ -96,14 +102,19 @@ namespace NervaOneWalletMiner.Views
                     if (_colId != null) { _colId.IsVisible = false; }
                     if (_colAddress != null) { _colAddress.IsVisible = true; }
                     if (_colUnlocked != null) { _colUnlocked.IsVisible = false; }
+
+                    // Medium: empty state button centered
+                    spEmptyState.VerticalAlignment = VerticalAlignment.Center;
+                    spEmptyStateButtons.HorizontalAlignment = HorizontalAlignment.Center;
+                    SetEmptyStateButtonAlignment(HorizontalAlignment.Center);
                 }
                 else
                 {
-                    // Wide: Open Wallet button on the right of icon/label
+                    // Wide: Close Wallet button on the right of icon/label
                     grdHeader.ColumnDefinitions = ColumnDefinitions.Parse("Auto,*,Auto");
-                    Grid.SetRow(btnOpenCloseWallet, 0);
-                    Grid.SetColumn(btnOpenCloseWallet, 2);
-                    btnOpenCloseWallet.Margin = new Thickness(0, 0, 5, 0);
+                    Grid.SetRow(btnCloseWallet, 0);
+                    Grid.SetColumn(btnCloseWallet, 2);
+                    btnCloseWallet.Margin = new Thickness(0, 0, 5, 0);
 
                     // Wide: Transfer/Address buttons on the right
                     grdStats.ColumnDefinitions = ColumnDefinitions.Parse("200,*,200");
@@ -116,6 +127,11 @@ namespace NervaOneWalletMiner.Views
                     if (_colId != null) { _colId.IsVisible = true; }
                     if (_colAddress != null) { _colAddress.IsVisible = true; }
                     if (_colUnlocked != null) { _colUnlocked.IsVisible = !GlobalData.CoinSettings[GlobalData.AppSettings.ActiveCoin].IsWalletBtcStyle; }
+
+                    // Wide: empty state button centered
+                    spEmptyState.VerticalAlignment = VerticalAlignment.Center;
+                    spEmptyStateButtons.HorizontalAlignment = HorizontalAlignment.Center;
+                    SetEmptyStateButtonAlignment(HorizontalAlignment.Center);
                 }
             }
             catch (Exception ex)
@@ -124,10 +140,22 @@ namespace NervaOneWalletMiner.Views
             }
         }
 
+        // Alignment has to be set on buttons themselves. Setting it on their panel is not enough as
+        // buttons keep their own width and end up sitting off to the side of centered message
+        private void SetEmptyStateButtonAlignment(HorizontalAlignment alignment)
+        {
+            btnEmptySetUpWallet.HorizontalAlignment = alignment;
+            btnEmptyOpenWallet.HorizontalAlignment = alignment;
+        }
+
         private void WalletView_Initialized(object? sender, EventArgs e)
         {
             try
             {
+                // Master timer refreshes this too but that can take a few seconds. New user landing here
+                // should not have to wait to find out they need to create a wallet
+                UIManager.RefreshWalletEmptyState();
+
                 if (!GlobalData.AreWalletEventsRegistered)
                 {
                     WalletViewModel vm = (WalletViewModel)DataContext!;
@@ -143,43 +171,61 @@ namespace NervaOneWalletMiner.Views
         }
 
         #region Open Wallet
-        public async void OpenCloseWallet_Clicked(object sender, RoutedEventArgs args)
+        // Only reachable from empty state. Once a wallet is open, empty state is replaced by accounts grid
+        public async void EmptyOpenWallet_Clicked(object sender, RoutedEventArgs args)
         {
             try
             {
-                var btnOpenCloseWallet = this.Get<Button>("btnOpenCloseWallet");
-
-                if (btnOpenCloseWallet.Content!.ToString()!.Equals(StatusWallet.OpenWallet))
+                if (GlobalData.DaemonState == DaemonState.CliToolsMissing || GlobalData.DaemonState == DaemonState.Downloading)
                 {
-                    if (GlobalData.DaemonState == DaemonState.CliToolsMissing || GlobalData.DaemonState == DaemonState.Downloading)
+                    Logger.LogDebug("WAL.EOWC", "Trying to open wallet but CLI tools not found");
+                    await DialogService.ShowAsync(new MessageBoxView("Open Wallet", "Client tools missing. Cannot open wallet until client tools are downloaded and running", true));
+                }
+                else if (!GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].IsWalletOnly && GlobalData.DaemonState != DaemonState.Running)
+                {
+                    Logger.LogDebug("WAL.EOWC", "Trying to open wallet but daemon not running");
+                    await DialogService.ShowAsync(new MessageBoxView("Open Wallet", "Daemon not running. Cannot open wallet until connection is established", true));
+                }
+                else if (GlobalMethods.GetWalletFileNames().Count == 0)
+                {
+                    // Empty state shows Wallet Setup button when there are no wallets, so this only happens
+                    // if wallets went missing since it was last checked. Open Wallet page would be empty
+                    Logger.LogDebug("WAL.EOWC", "Trying to open wallet but no wallets found");
+                    DialogResult? result = await DialogService.ShowAsync<DialogResult>(new MessageBoxView("Open Wallet", "No wallets were found.\r\n\r\nWould you like to set one up now?", false, true));
+                    if (result != null && result.IsOk)
                     {
-                        Logger.LogDebug("WAL.OCWC", "Trying to open wallet but CLI tools not found");
-                        await DialogService.ShowAsync(new MessageBoxView("Open Wallet", "Client tools missing. Cannot open wallet until client tools are downloaded and running", true));
-                    }
-                    else if (!GlobalData.AppSettings.Daemon[GlobalData.AppSettings.ActiveCoin].IsWalletOnly && GlobalData.DaemonState != DaemonState.Running)
-                    {
-                        Logger.LogDebug("WAL.OCWC", "Trying to open wallet but daemon not running");
-                        await DialogService.ShowAsync(new MessageBoxView("Open Wallet", "Daemon not running. Cannot open wallet until connection is established", true));
-                    }
-                    else
-                    {
-                        Logger.LogDebug("WAL.OCWC", "Navigating to Open Wallet page");
-                        UIManager.NavigateToOpenWallet();
+                        UIManager.NavigateToPage(SplitViewPages.WalletSetup);
                     }
                 }
                 else
                 {
-                    // Close wallet
-                    await CloseUserWallet();
-                    btnOpenCloseWallet.Content = StatusWallet.OpenWallet;
+                    Logger.LogDebug("WAL.EOWC", "Navigating to Open Wallet page");
+                    UIManager.NavigateToOpenWallet();
                 }
             }
             catch (Exception ex)
             {
-                Logger.LogException("WAL.OCWC", ex);
+                Logger.LogException("WAL.EOWC", ex);
             }
         }
         #endregion // Open Wallet
+
+        #region Empty State
+        // Wallet Setup is where wallets are created and restored, which is not obvious to a new user
+        // looking at Wallet page. Sending them there also keeps Cancel taking them back to same place
+        public void EmptySetUpWallet_Clicked(object sender, RoutedEventArgs args)
+        {
+            try
+            {
+                Logger.LogDebug("WAL.ESWC", "Navigating to Wallet Setup page");
+                UIManager.NavigateToPage(SplitViewPages.WalletSetup);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("WAL.ESWC", ex);
+            }
+        }
+        #endregion // Empty State
 
         #region Create Account
         private void CreateAccount_Clicked(object sender, RoutedEventArgs args)
@@ -353,6 +399,21 @@ namespace NervaOneWalletMiner.Views
         #endregion // Address Info
 
         #region Close Wallet
+        public async void CloseWallet_Clicked(object sender, RoutedEventArgs args)
+        {
+            try
+            {
+                await CloseUserWallet();
+
+                // Bring empty state up right away instead of waiting for next master timer tick
+                UIManager.RefreshWalletEmptyState();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("WAL.CLWC", ex);
+            }
+        }
+
         private async Task<bool> CloseUserWalletNonUi()
         {
             // Need to wait until wallet is closed or might as well not even attempt this


### PR DESCRIPTION
- Show what to do next instead of an empty grid when no wallet is open: send users with no wallets to Wallet Setup, and everyone else to opening one
- Hide balances, wallet actions and Transaction Details while the empty state is up so there is room for it on a phone
- Make the Wallet header button close only, now that opening happens from the empty state, and drop the unused OpenCloseWallet properties and StatusWallet class
- Move wallet file lookup to GlobalMethods so both screens and the Open Wallet page share one list